### PR TITLE
Introducing managed mode for jxscout pro v2

### DIFF
--- a/caido.config.ts
+++ b/caido.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   name: "jxscout",
   description:
     "Plugin to ingest requests from Caido into jxscout (https://github.com/francisconeves97/jxscout)",
-  version: "0.4.1",
+  version: "0.5.0",
   author: {
     name: "Francisco Neves",
     email: "dev@caido.io",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "watch": "caido-dev watch"
   },
   "devDependencies": {
-    "@caido-community/dev": "^0.1.3",
+    "@caido-community/dev": "0.1.6",
     "@caido/tailwindcss": "0.0.1",
-    "@vitejs/plugin-vue": "5.2.1",
-    "postcss-prefixwrap": "1.51.0",
+    "@vitejs/plugin-vue": "6.0.1",
+    "postcss-prefixwrap": "1.57.2",
     "tailwindcss": "3.4.13",
-    "tailwindcss-primeui": "0.3.4",
-    "typescript": "5.5.4"
+    "tailwindcss-primeui": "0.6.1",
+    "typescript": "5.8.3"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,6 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@caido/sdk-backend": "^0.51.1"
+    "@caido/sdk-backend": "0.56.0",
+    "@caido/sdk-shared": "0.2.2"
   }
 }

--- a/packages/backend/src/binary.ts
+++ b/packages/backend/src/binary.ts
@@ -1,0 +1,213 @@
+import { spawn } from "child_process";
+import { access } from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+const BINARY_NAME = "jxscout-pro-v2";
+const MANAGED_DIR = ".jxscout-pro";
+const MANAGED_BIN_SUBDIR = "bin";
+
+const VALIDATE_TIMEOUT_MS = 2000;
+const WHICH_TIMEOUT_MS = 2000;
+
+export type BinarySource = "custom" | "path" | "managed";
+
+export type DetectionResult =
+  | { source: BinarySource; path: string }
+  | { source: null; path: null };
+
+export type ValidationResult = {
+  valid: boolean;
+  version?: string;
+  error?: string;
+};
+
+const managedBinaryPath = (): string =>
+  path.join(os.homedir(), MANAGED_DIR, MANAGED_BIN_SUBDIR, BINARY_NAME);
+
+const fileAccessible = async (p: string): Promise<boolean> => {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Runs a command and captures stdout / stderr / exit. Always uses an array of
+// args (no shell substitution). Enforces a wall-clock timeout via setTimeout +
+// child.kill() so a hung subprocess never wedges the RPC. Failures are returned
+// instead of thrown so callers don't have to wrap us in try/catch -- matching
+// the "collapse to null" discipline used by fetchJxscoutStatus.
+//
+// Discipline (carried over from Phase 4):
+// - No `{ shell: true }` -- caller passes exact argv. A malicious string in
+//   `cmd` cannot inject shell metacharacters because there's no shell.
+// - No AbortSignal.timeout(): manual setTimeout + clearTimeout in finally.
+//   AbortSignal.timeout() segfaulted LLRT during Phase 4.
+type SpawnResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  error: string | null;
+};
+
+const runOnce = (
+  cmd: string,
+  args: readonly string[],
+  timeoutMs: number
+): Promise<SpawnResult> => {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    let stdout = "";
+    let stderr = "";
+
+    let child;
+    try {
+      child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch (err) {
+      resolve({
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        error: String(err),
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // swallow -- the process may have just exited.
+      }
+    }, timeoutMs);
+
+    const settle = (exitCode: number | null, errString: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode, stdout, stderr, timedOut, error: errString });
+    };
+
+    child.stdout?.on("data", (chunk: unknown) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk: unknown) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err: Error) => {
+      settle(null, err.message ?? String(err));
+    });
+    child.on("close", (code: number | null) => {
+      settle(code, null);
+    });
+  });
+};
+
+// Spawns `<binaryPath> --version`, 2s timeout, returns whether it looks like a
+// jxscout build. Per Phase 5 decision the match is RELAXED: any output
+// containing "jxscout" (case-insensitive) counts. This is friendlier during
+// dogfooding when the dev binary is `tui` (which would not start with
+// "jxscout-pro" but does include the project name in its banner).
+//
+// Phase 8: the released jxscout-pro-v2 2.1.1 predates clap `--version` (added
+// in jxscout-rs#42), so it rejects the flag with "unexpected argument
+// '--version'" (exit 2). We treat that specific stderr pattern as a soft
+// success -- `version` is left empty and the real version surfaces via
+// /health post-spawn. Auto-launch and Start on a fresh-install 2.1.1 binary
+// both work; if the user has typed a non-jxscout binary path that happens to
+// reject --version, the /health probe rejects it within the 5s start window.
+const UNEXPECTED_VERSION_FLAG = /unexpected argument.*--version/i;
+
+export const validateBinary = async (
+  binaryPath: string
+): Promise<ValidationResult> => {
+  if (typeof binaryPath !== "string" || binaryPath.trim().length === 0) {
+    return { valid: false, error: "Empty binary path" };
+  }
+  // Pre-check accessibility so the error attributes the failure correctly
+  // (otherwise a missing file shows up as an opaque ENOENT spawn error).
+  if (!(await fileAccessible(binaryPath))) {
+    return { valid: false, error: `Path not accessible: ${binaryPath}` };
+  }
+
+  const result = await runOnce(binaryPath, ["--version"], VALIDATE_TIMEOUT_MS);
+  if (result.timedOut) {
+    return {
+      valid: false,
+      error: `--version timed out after ${VALIDATE_TIMEOUT_MS}ms`,
+    };
+  }
+  if (result.error) {
+    return { valid: false, error: result.error };
+  }
+  if (result.exitCode !== 0) {
+    const combined = `${result.stderr}\n${result.stdout}`;
+    // Pre-2.1.2 binary: clap rejects --version. Accept as a soft-valid;
+    // /health will be the authoritative version source post-spawn.
+    if (UNEXPECTED_VERSION_FLAG.test(combined)) {
+      return { valid: true, version: undefined };
+    }
+    const detail = (result.stderr.trim() || result.stdout.trim()).slice(0, 200);
+    return {
+      valid: false,
+      error: `--version exited ${result.exitCode}${detail ? `: ${detail}` : ""}`,
+    };
+  }
+  const stdout = result.stdout.trim();
+  if (!/jxscout/i.test(stdout)) {
+    return {
+      valid: false,
+      error: `--version output does not contain "jxscout": ${stdout.slice(0, 200)}`,
+    };
+  }
+  return { valid: true, version: stdout };
+};
+
+const detectViaWhich = async (): Promise<string | null> => {
+  // `which` on Unix, `where` on Windows. Both write the resolved path(s) to
+  // stdout, one per line. `where` may emit multiple matches; we take the first.
+  const tool = os.platform() === "win32" ? "where" : "which";
+  const result = await runOnce(tool, [BINARY_NAME], WHICH_TIMEOUT_MS);
+  if (result.timedOut || result.exitCode !== 0 || result.error) {
+    return null;
+  }
+  const firstLine = result.stdout
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
+  if (!firstLine) return null;
+  if (!(await fileAccessible(firstLine))) return null;
+  return firstLine;
+};
+
+// Discovery order matches the plan: custom path → which/where → managed dir.
+// A custom path that no longer exists silently falls through to the next
+// source rather than returning null -- this lets a user who removed the file
+// recover via PATH or the managed install without first clearing the setting.
+export const detectBinary = async (
+  customPath?: string | null
+): Promise<DetectionResult> => {
+  const trimmed =
+    typeof customPath === "string" ? customPath.trim() : "";
+  if (trimmed.length > 0 && (await fileAccessible(trimmed))) {
+    return { source: "custom", path: trimmed };
+  }
+
+  const fromPath = await detectViaWhich();
+  if (fromPath) {
+    return { source: "path", path: fromPath };
+  }
+
+  const managed = managedBinaryPath();
+  if (await fileAccessible(managed)) {
+    return { source: "managed", path: managed };
+  }
+
+  return { source: null, path: null };
+};

--- a/packages/backend/src/download.ts
+++ b/packages/backend/src/download.ts
@@ -1,0 +1,531 @@
+import type { SDK } from "caido:plugin";
+import { fetch } from "caido:http";
+import { spawn, type ChildProcess } from "child_process";
+import { chmod, mkdir, mkdtemp, readdir, rename, rm, writeFile } from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { readLicense } from "./license";
+
+// Marketing site's v2 download endpoint. Resolver pattern:
+//   GET https://jxscout.app/api/v2/download?type={releaseType}&version=latest&licenseKey={key}
+//   -> { downloadUrl, version }
+// `downloadUrl` is a Keygen-validated R2 presigned URL pointing at a tar.gz
+// (Unix) or .zip (Windows). Tarball contents are a single top-level file:
+// `jxscout-pro-v2` (Unix) or `jxscout-pro-v2.exe` (Windows). See
+// bun/marketing-website/src/app/api/v2/download/route.ts + scripts/local-release.sh.
+const RESOLVER_BASE_URL = "https://jxscout.app/api/v2/download";
+
+// Floor for the binary version we'll install. If the resolver's `latest`
+// answer is below this (which can happen if the marketing site's
+// LATEST_VERSION_CLI_V2 constant lags behind an uploaded release), we re-ask
+// for this version explicitly. Bumped here when the plugin starts depending
+// on features only present in a newer jxscout-pro-v2 (e.g. the runtime
+// POST /scope endpoint landed in 2.1.2).
+const MIN_BINARY_VERSION = "2.1.2";
+
+// Lightweight semver-ish comparator. Parses major.minor.patch off the front
+// and treats anything trailing (e.g. "-beta18", "-rc1") as a pre-release,
+// which sorts *below* the same X.Y.Z without a suffix. That matches semver's
+// pre-release rule and is sufficient for the resolver's version vocabulary:
+//
+//   "2.1.2"        -> not lower
+//   "2.1.2-rc1"    -> lower (pre-release of same X.Y.Z)
+//   "2.1.0"        -> lower
+//   "2.0.0-beta18" -> lower
+//   "2.1.3"        -> not lower
+//
+// Unparseable inputs are conservatively treated as lower so we upgrade rather
+// than ship whatever malformed thing the resolver returned.
+const isVersionLowerThanMin = (version: string): boolean => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(version);
+  if (!match) return true;
+  const have: [number, number, number] = [
+    parseInt(match[1] ?? "0", 10),
+    parseInt(match[2] ?? "0", 10),
+    parseInt(match[3] ?? "0", 10),
+  ];
+  const wantParts = MIN_BINARY_VERSION.split(".");
+  const want: [number, number, number] = [
+    parseInt(wantParts[0] ?? "0", 10),
+    parseInt(wantParts[1] ?? "0", 10),
+    parseInt(wantParts[2] ?? "0", 10),
+  ];
+  for (let i = 0; i < 3; i++) {
+    if (have[i]! < want[i]!) return true;
+    if (have[i]! > want[i]!) return false;
+  }
+  // Numeric prefix equals MIN_BINARY_VERSION -- only "lower" if it carries
+  // a pre-release suffix.
+  return (match[4] ?? "").startsWith("-");
+};
+
+// Phase 4 LLRT lesson: AbortSignal.timeout(ms) segfaults the runtime when
+// fetch fails with ECONNREFUSED. Same risk profile here (offline at install
+// time is plausible). Use explicit AbortController + setTimeout, clearTimeout
+// in finally.
+const RESOLVER_TIMEOUT_MS = 10_000;
+// Download timeout has to be generous: ~50MB over a slow connection. 10
+// minutes is the wall clock; the user can cancel via abort if they need to.
+const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+const EXTRACT_TIMEOUT_MS = 60_000;
+
+const MANAGED_DIR = ".jxscout-pro";
+const MANAGED_BIN_SUBDIR = "bin";
+const BINARY_NAME_UNIX = "jxscout-pro-v2";
+const BINARY_NAME_WIN = "jxscout-pro-v2.exe";
+
+export type DownloadProgress =
+  | { kind: "resolving" }
+  | { kind: "downloading"; bytes: number; total: number | null }
+  | { kind: "extracting" }
+  | { kind: "installing" }
+  | { kind: "done"; path: string; version: string }
+  | { kind: "error"; error: string };
+
+export type ReleaseType =
+  | "linux-386"
+  | "linux-amd64"
+  | "linux-arm64"
+  | "macos-amd64"
+  | "macos-arm64"
+  | "windows-amd64"
+  | "windows-arm64";
+
+export type DownloadResult =
+  | { success: true; path: string; version: string }
+  | { success: false; error: string };
+
+// Maps Node-style os.platform()/os.arch() to the ReleaseType strings the
+// marketing site recognises. Returns null when the host platform isn't a
+// supported jxscout-pro-v2 target (e.g. freebsd, openbsd, sunos).
+//
+// LLRT exposes Node-shape values: os.platform() ∈ {darwin,linux,win32},
+// os.arch() ∈ {x64,arm64,ia32}. "ia32" is the only oddball: marketing site
+// calls this "linux-386".
+export const releaseTypeForCurrentPlatform = (): ReleaseType | null => {
+  const platform = os.platform();
+  const arch = os.arch();
+  if (platform === "darwin") {
+    if (arch === "arm64") return "macos-arm64";
+    if (arch === "x64") return "macos-amd64";
+    return null;
+  }
+  if (platform === "linux") {
+    if (arch === "arm64") return "linux-arm64";
+    if (arch === "x64") return "linux-amd64";
+    if (arch === "ia32") return "linux-386";
+    return null;
+  }
+  if (platform === "win32") {
+    if (arch === "arm64") return "windows-arm64";
+    if (arch === "x64") return "windows-amd64";
+    return null;
+  }
+  return null;
+};
+
+const managedBinDir = (): string =>
+  path.join(os.homedir(), MANAGED_DIR, MANAGED_BIN_SUBDIR);
+
+const finalBinaryPath = (): string =>
+  path.join(
+    managedBinDir(),
+    os.platform() === "win32" ? BINARY_NAME_WIN : BINARY_NAME_UNIX
+  );
+
+const archiveExtensionForPlatform = (): "zip" | "tar.gz" =>
+  os.platform() === "win32" ? "zip" : "tar.gz";
+
+// LLRT's `sdk.api.send` types as `never` at this layer because the parent
+// Spec lives in index.ts and importing it would create a circular dep. The
+// frontend's `onEvent` still type-checks against Spec["events"], so the
+// contract holds where consumers actually live. Same trick the supervisor
+// uses for "supervisor-state".
+type LooseSend = (event: string, ...args: unknown[]) => void;
+
+const emit = (sdk: SDK, progress: DownloadProgress): void => {
+  try {
+    (sdk.api.send as unknown as LooseSend)("download-progress", progress);
+  } catch (err) {
+    sdk.console.error(`download: failed to emit progress: ${err}`);
+  }
+};
+
+// Resolver call: validates the license + maps {type, version} to an R2
+// presigned URL. Failure modes: 400 (bad type), 401 (invalid license), 500
+// (R2 issue) -- surface the server's `error` field verbatim so the user
+// sees the real reason.
+type ResolverResponse = {
+  downloadUrl: string;
+  version: string;
+};
+
+const resolveDownloadUrl = async (
+  sdk: SDK,
+  releaseType: ReleaseType,
+  licenseKey: string,
+  version: string
+): Promise<ResolverResponse> => {
+  const url =
+    `${RESOLVER_BASE_URL}` +
+    `?type=${encodeURIComponent(releaseType)}` +
+    `&version=${encodeURIComponent(version)}` +
+    `&licenseKey=${encodeURIComponent(licenseKey)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    try {
+      controller.abort();
+    } catch {
+      // swallow
+    }
+  }, RESOLVER_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    const raw = (await response.json()) as unknown;
+    if (!response.ok) {
+      const message =
+        raw && typeof raw === "object" && "error" in raw &&
+        typeof (raw as { error: unknown }).error === "string"
+          ? (raw as { error: string }).error
+          : `HTTP ${response.status}`;
+      throw new Error(`Resolver rejected request: ${message}`);
+    }
+    if (
+      !raw ||
+      typeof raw !== "object" ||
+      typeof (raw as { downloadUrl?: unknown }).downloadUrl !== "string" ||
+      typeof (raw as { version?: unknown }).version !== "string"
+    ) {
+      throw new Error("Resolver returned a malformed payload");
+    }
+    return raw as ResolverResponse;
+  } catch (err) {
+    sdk.console.error(`download: resolver call failed: ${err}`);
+    throw err instanceof Error ? err : new Error(String(err));
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// caido:http's Response.body is `null` (NOT a ReadableStream), so streaming
+// to disk isn't possible -- we have to buffer the whole body via
+// arrayBuffer(). For a ~50MB binary this is fine inside LLRT/QuickJS.
+//
+// Caveat: the progress event can only report start+end, not byte-by-byte.
+// We emit a single `downloading` event with `total` from Content-Length (so
+// the frontend can show "Downloading 52 MB..." instead of an indefinite
+// spinner) before awaiting the bytes. When `total` is unknown we emit null.
+const downloadArchiveToDisk = async (
+  sdk: SDK,
+  downloadUrl: string,
+  destPath: string
+): Promise<void> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    try {
+      controller.abort();
+    } catch {
+      // swallow
+    }
+  }, DOWNLOAD_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(downloadUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Download HTTP ${response.status}`);
+    }
+
+    const contentLength = response.headers.get("content-length");
+    const total =
+      contentLength !== null && /^\d+$/.test(contentLength)
+        ? parseInt(contentLength, 10)
+        : null;
+    emit(sdk, { kind: "downloading", bytes: 0, total });
+
+    const buffer = await response.arrayBuffer();
+    emit(sdk, {
+      kind: "downloading",
+      bytes: buffer.byteLength,
+      total: total ?? buffer.byteLength,
+    });
+
+    await writeFile(destPath, new Uint8Array(buffer));
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// Spawn-with-timeout helper, runOnce-style. Same shape Phase 5/6 settled on:
+// no shell, argv array, manual setTimeout + child.kill('SIGKILL') for
+// wall-clock enforcement, `close` (not `exit`) as the settle event.
+type ShortSpawnResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  error: string | null;
+};
+
+const runShort = (
+  cmd: string,
+  args: readonly string[],
+  timeoutMs: number
+): Promise<ShortSpawnResult> => {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    let stdout = "";
+    let stderr = "";
+
+    let child: ChildProcess;
+    try {
+      child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch (err) {
+      resolve({
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        error: String(err),
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // swallow
+      }
+    }, timeoutMs);
+
+    const settle = (exitCode: number | null, errString: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode, stdout, stderr, timedOut, error: errString });
+    };
+
+    child.stdout?.on("data", (chunk: unknown) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk: unknown) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err: Error) => {
+      settle(null, err.message ?? String(err));
+    });
+    child.on("close", (code: number | null) => {
+      settle(code, null);
+    });
+  });
+};
+
+// `tar` ships with macOS, Linux, and modern Windows (since Win10 1803 — it's
+// bsdtar under the hood and handles both .tar.gz and .zip). Using one tool
+// across all three avoids a `unzip`-on-Windows availability question.
+const extractArchive = async (
+  archivePath: string,
+  extractDir: string
+): Promise<void> => {
+  const args =
+    archiveExtensionForPlatform() === "tar.gz"
+      ? ["-xzf", archivePath, "-C", extractDir]
+      : ["-xf", archivePath, "-C", extractDir];
+  const result = await runShort("tar", args, EXTRACT_TIMEOUT_MS);
+  if (result.timedOut) {
+    throw new Error(`tar timed out after ${EXTRACT_TIMEOUT_MS}ms`);
+  }
+  if (result.error) {
+    throw new Error(`tar spawn failed: ${result.error}`);
+  }
+  if (result.exitCode !== 0) {
+    const detail = (result.stderr.trim() || result.stdout.trim()).slice(0, 400);
+    throw new Error(`tar exited ${result.exitCode}${detail ? `: ${detail}` : ""}`);
+  }
+};
+
+// On macOS, freshly-downloaded binaries inherit the
+// `com.apple.quarantine` extended attribute, which makes Gatekeeper block
+// the first launch ("cannot be verified"). Strip it best-effort. Skip
+// entirely on Linux/Windows (no xattr there, attempting would just log
+// noise).
+const stripQuarantineAttribute = async (
+  sdk: SDK,
+  targetPath: string
+): Promise<void> => {
+  if (os.platform() !== "darwin") return;
+  const result = await runShort(
+    "xattr",
+    ["-d", "com.apple.quarantine", targetPath],
+    5000
+  );
+  // xattr exits non-zero when the attribute isn't set, which is fine.
+  if (result.exitCode !== 0 && result.exitCode !== null) {
+    sdk.console.log(
+      `download: xattr strip non-fatal exit ${result.exitCode} (likely no quarantine to strip)`
+    );
+  }
+};
+
+// Locate the binary inside the extracted dir. The release tarballs/zips
+// contain a single top-level file matching `jxscout-pro-v2[.exe]`. Fall back
+// to a one-level-deep search in case future releases nest the file (eg
+// under a versioned dirname).
+const locateExtractedBinary = async (extractDir: string): Promise<string> => {
+  const target =
+    os.platform() === "win32" ? BINARY_NAME_WIN : BINARY_NAME_UNIX;
+
+  const top = await readdir(extractDir, { withFileTypes: true });
+  for (const entry of top) {
+    if (entry.isFile() && entry.name === target) {
+      return path.join(extractDir, entry.name);
+    }
+  }
+  for (const entry of top) {
+    if (entry.isDirectory()) {
+      const inner = await readdir(path.join(extractDir, entry.name), {
+        withFileTypes: true,
+      });
+      for (const child of inner) {
+        if (child.isFile() && child.name === target) {
+          return path.join(extractDir, entry.name, child.name);
+        }
+      }
+    }
+  }
+  throw new Error(`Binary '${target}' not found in extracted archive`);
+};
+
+// installBinary owns the post-download chain: extract, locate, move-into-place,
+// chmod, strip xattr. Phase 7 question: the user chose to put this all in one
+// spot rather than two RPCs. Keeping the public surface narrow -- downloadBinary
+// does the whole thing.
+const installBinary = async (
+  sdk: SDK,
+  archivePath: string
+): Promise<string> => {
+  emit(sdk, { kind: "extracting" });
+
+  const binDir = managedBinDir();
+  await mkdir(binDir, { recursive: true, mode: 0o755 });
+
+  const extractDir = await mkdtemp(
+    path.join(os.tmpdir(), "jxscout-pro-extract-")
+  );
+
+  try {
+    await extractArchive(archivePath, extractDir);
+    const extractedBinary = await locateExtractedBinary(extractDir);
+
+    emit(sdk, { kind: "installing" });
+
+    const finalPath = finalBinaryPath();
+    // rename across the same filesystem is atomic. If the old binary is
+    // currently running, rename still succeeds on Unix (the running process
+    // holds an open fd to the old inode); the new file simply takes its
+    // place for future launches. On Windows this fails with EBUSY, so try
+    // to rm the existing file first and let rename create fresh.
+    await rm(finalPath, { force: true });
+    await rename(extractedBinary, finalPath);
+
+    if (os.platform() !== "win32") {
+      await chmod(finalPath, 0o755);
+    }
+    await stripQuarantineAttribute(sdk, finalPath);
+
+    return finalPath;
+  } finally {
+    // Best-effort cleanup of the temp extract dir.
+    try {
+      await rm(extractDir, { recursive: true, force: true });
+    } catch (err) {
+      sdk.console.log(`download: temp dir cleanup failed (ignored): ${err}`);
+    }
+  }
+};
+
+// Public entry point. Reads the license, resolves the download URL, fetches
+// the archive, extracts, installs. Emits progress events at each stage. All
+// failure modes collapse into DownloadResult — the frontend has a single
+// shape to render against.
+export const downloadBinary = async (sdk: SDK): Promise<DownloadResult> => {
+  try {
+    emit(sdk, { kind: "resolving" });
+
+    const releaseType = releaseTypeForCurrentPlatform();
+    if (releaseType === null) {
+      const message = `Unsupported platform: ${os.platform()}/${os.arch()}`;
+      emit(sdk, { kind: "error", error: message });
+      return { success: false, error: message };
+    }
+
+    const license = await readLicense();
+    if (!license || license.license_key.length === 0) {
+      const message = "No license on disk; activate first";
+      emit(sdk, { kind: "error", error: message });
+      return { success: false, error: message };
+    }
+
+    let resolved = await resolveDownloadUrl(
+      sdk,
+      releaseType,
+      license.license_key,
+      "latest"
+    );
+
+    // If the resolver answered with a version below our floor, retry with an
+    // explicit version pin so we don't install a binary missing features the
+    // plugin depends on. Best-effort: if the retry fails (e.g. the pinned
+    // version isn't in the resolver's allowlist), fall back to whatever
+    // `latest` already gave us rather than failing the whole install.
+    if (isVersionLowerThanMin(resolved.version)) {
+      sdk.console.log(
+        `download: resolver returned ${resolved.version}; retrying for ${MIN_BINARY_VERSION}`
+      );
+      try {
+        resolved = await resolveDownloadUrl(
+          sdk,
+          releaseType,
+          license.license_key,
+          MIN_BINARY_VERSION
+        );
+      } catch (err) {
+        sdk.console.error(
+          `download: pinned-version retry failed (${err}); keeping ${resolved.version}`
+        );
+      }
+    }
+
+    const binDir = managedBinDir();
+    await mkdir(binDir, { recursive: true, mode: 0o755 });
+    const tmpArchivePath = path.join(
+      binDir,
+      `.download.${archiveExtensionForPlatform()}`
+    );
+
+    try {
+      await downloadArchiveToDisk(sdk, resolved.downloadUrl, tmpArchivePath);
+      const finalPath = await installBinary(sdk, tmpArchivePath);
+      emit(sdk, { kind: "done", path: finalPath, version: resolved.version });
+      return { success: true, path: finalPath, version: resolved.version };
+    } finally {
+      // Always clean up the temp archive (success or failure). Ignore errors;
+      // the file may already be gone if installBinary moved it.
+      try {
+        await rm(tmpArchivePath, { force: true });
+      } catch {
+        // swallow
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    sdk.console.error(`downloadBinary failed: ${message}`);
+    emit(sdk, { kind: "error", error: message });
+    return { success: false, error: message };
+  }
+};

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,13 +1,85 @@
-import type { DefineAPI, SDK } from "caido:plugin";
+import type { SDK } from "caido:plugin";
 import { RequestSpec } from "caido:utils";
+import { Blob, fetch } from "caido:http";
+import type { DefinePluginPackageSpec } from "@caido/sdk-shared";
+import { spawn } from "child_process";
 import { readFile, writeFile } from "fs/promises";
+import * as os from "os";
 import * as path from "path";
-import { Response, Settings } from "./types";
+
+import {
+  DetectionResult,
+  ValidationResult,
+  detectBinary,
+  validateBinary,
+} from "./binary";
+import {
+  DownloadProgress,
+  DownloadResult,
+  ReleaseType,
+  downloadBinary as downloadBinaryFn,
+  releaseTypeForCurrentPlatform,
+} from "./download";
+import {
+  clearLicense as clearLicenseFile,
+  hasLicense as hasLicenseFile,
+  readLicense,
+  writeLicense,
+} from "./license";
+import {
+  StartResult,
+  StopResult,
+  SupervisorSnapshot,
+  findFreePort,
+  getSupervisorState,
+  recoverOrphan,
+  restartJxscout as restartJxscoutFn,
+  startJxscout as startJxscoutFn,
+  stopJxscout as stopJxscoutFn,
+} from "./supervisor";
+import {
+  JxscoutStatus,
+  ProjectEntry,
+  Response,
+  Settings,
+  StoredLicense,
+} from "./types";
+
+export type {
+  JxscoutStatus,
+  Mode,
+  ProjectEntry,
+  Response,
+  Settings,
+  StoredLicense,
+} from "./types";
+export type { BinarySource, DetectionResult, ValidationResult } from "./binary";
+export type {
+  DownloadProgress,
+  DownloadResult,
+  ReleaseType,
+} from "./download";
+export type {
+  StartResult,
+  StopResult,
+  SupervisorSnapshot,
+  SupervisorStateName,
+} from "./supervisor";
+
+const STATUS_FETCH_TIMEOUT_MS = 1000;
+// /scope responds quickly (just an ArcSwap store + tracing log), but keep some
+// headroom for cold-start cases. Matches PROJECTS_FETCH_TIMEOUT_MS.
+const SCOPE_PUSH_TIMEOUT_MS = 1500;
 
 const DEFAULT_SETTINGS: Settings = {
-  port: 3333,
   host: "localhost",
-  filterInScope: true,
+  port: 3333,
+  filterInScope: false,
+  mode: "manual",
+  customBinaryPath: null,
+  defaultProjectsDir: null,
+  autoLaunch: true,
+  autoSync: true,
 };
 
 let globalSettings: Settings | null = null;
@@ -30,16 +102,73 @@ const getSettingsFilePath = (sdk: SDK) => {
   return path.join(sdk.meta.path(), "settings.json");
 };
 
-const saveSettings = async (sdk: SDK, settings: Settings) => {
+// Additive migration: keep every known field that parses; fill the rest with
+// defaults. Tolerates the legacy {host,port,filterInScope} shape and any
+// future garbage by clamping to declared types instead of crashing. Unknown
+// fields (e.g. legacy lastIntendedState/manualProjectName/manualInScope)
+// are silently dropped on load.
+const migrateSettings = (raw: unknown): Settings => {
+  const parsed: Record<string, unknown> =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+
+  const stringOrNull = (v: unknown, fallback: string | null): string | null => {
+    if (typeof v === "string") return v;
+    if (v === null) return null;
+    return fallback;
+  };
+
+  const mode =
+    parsed.mode === "managed" || parsed.mode === "manual"
+      ? parsed.mode
+      : DEFAULT_SETTINGS.mode;
+
+  return {
+    host:
+      typeof parsed.host === "string" ? parsed.host : DEFAULT_SETTINGS.host,
+    port:
+      typeof parsed.port === "number" && Number.isFinite(parsed.port)
+        ? parsed.port
+        : DEFAULT_SETTINGS.port,
+    filterInScope:
+      typeof parsed.filterInScope === "boolean"
+        ? parsed.filterInScope
+        : DEFAULT_SETTINGS.filterInScope,
+    mode,
+    customBinaryPath: stringOrNull(
+      parsed.customBinaryPath,
+      DEFAULT_SETTINGS.customBinaryPath
+    ),
+    defaultProjectsDir: stringOrNull(
+      parsed.defaultProjectsDir,
+      DEFAULT_SETTINGS.defaultProjectsDir
+    ),
+    autoLaunch:
+      typeof parsed.autoLaunch === "boolean"
+        ? parsed.autoLaunch
+        : DEFAULT_SETTINGS.autoLaunch,
+    autoSync:
+      typeof parsed.autoSync === "boolean"
+        ? parsed.autoSync
+        : DEFAULT_SETTINGS.autoSync,
+  };
+};
+
+const saveSettings = async (
+  sdk: SDK,
+  incoming: Partial<Settings>
+): Promise<Response<Settings>> => {
   const settingsFilePath = getSettingsFilePath(sdk);
 
   try {
-    await writeFile(settingsFilePath, JSON.stringify(settings, null, 2));
+    // Normalise via migrateSettings so the on-disk file always lands in the
+    // canonical shape, even when an older frontend sends a partial payload.
+    const normalised = migrateSettings(incoming);
+    await writeFile(settingsFilePath, JSON.stringify(normalised, null, 2));
     sdk.console.log(`Settings saved to ${settingsFilePath}`);
 
-    globalSettings = settings;
+    globalSettings = normalised;
 
-    return ok(settings);
+    return ok(normalised);
   } catch (err) {
     sdk.console.error(`Failed to save settings: ${err}`);
 
@@ -53,22 +182,926 @@ const getSettings = async (sdk: SDK): Promise<Response<Settings>> => {
   sdk.console.log(`Loading settings from ${settingsFilePath}`);
 
   try {
-    const settings = await readFile(settingsFilePath, "utf-8");
-    return ok(JSON.parse(settings) as Settings);
+    const raw = await readFile(settingsFilePath, "utf-8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (parseErr) {
+      sdk.console.error(
+        `Failed to parse settings, using defaults: ${parseErr}`
+      );
+      return ok({ ...DEFAULT_SETTINGS });
+    }
+    return ok(migrateSettings(parsed));
   } catch (err) {
     sdk.console.error(`Failed to read settings: ${err}`);
-    return ok(DEFAULT_SETTINGS);
+    return ok({ ...DEFAULT_SETTINGS });
   }
 };
 
-export type API = DefineAPI<{
-  saveSettings: typeof saveSettings;
-  getSettings: typeof getSettings;
+const getLicenseHandler = async (
+  sdk: SDK
+): Promise<Response<StoredLicense | null>> => {
+  try {
+    return ok(await readLicense());
+  } catch (err) {
+    sdk.console.error(`Failed to read license: ${err}`);
+    return error(`Failed to read license: ${err}`);
+  }
+};
+
+const setLicenseHandler = async (
+  sdk: SDK,
+  key: string
+): Promise<Response<StoredLicense>> => {
+  try {
+    await writeLicense(key);
+    const stored = await readLicense();
+    if (!stored) {
+      return error("License written but could not be read back");
+    }
+    return ok(stored);
+  } catch (err) {
+    sdk.console.error(`Failed to write license: ${err}`);
+    return error(`Failed to write license: ${err}`);
+  }
+};
+
+const clearLicenseHandler = async (
+  sdk: SDK
+): Promise<Response<null>> => {
+  try {
+    await clearLicenseFile();
+    return ok(null);
+  } catch (err) {
+    sdk.console.error(`Failed to clear license: ${err}`);
+    return error(`Failed to clear license: ${err}`);
+  }
+};
+
+const hasLicenseHandler = async (
+  sdk: SDK
+): Promise<Response<boolean>> => {
+  try {
+    return ok(await hasLicenseFile());
+  } catch (err) {
+    sdk.console.error(`Failed to check license: ${err}`);
+    return error(`Failed to check license: ${err}`);
+  }
+};
+
+// Any failure -- timeout, refused, non-2xx, malformed JSON -- collapses to null
+// so the frontend has a single "disconnected" signal to render against.
+//
+// Uses an explicit AbortController + setTimeout rather than AbortSignal.timeout()
+// because the latter triggered a segfault inside the LLRT runtime when fetch
+// failed with ECONNREFUSED (caido-cli crashed mid-call during Phase 4 dev).
+const fetchJxscoutStatus = async (
+  sdk: SDK,
+  host: string,
+  port: number
+): Promise<JxscoutStatus | null> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    try {
+      controller.abort();
+    } catch {
+      // swallow
+    }
+  }, STATUS_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`http://${host}:${port}/health`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const raw = (await response.json()) as unknown;
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    const obj = raw as Record<string, unknown>;
+    if (
+      typeof obj.status !== "string" ||
+      typeof obj.project !== "string" ||
+      typeof obj.working_directory !== "string" ||
+      typeof obj.version !== "string"
+    ) {
+      return null;
+    }
+    return {
+      status: obj.status,
+      project: obj.project,
+      working_directory: obj.working_directory,
+      version: obj.version,
+    };
+  } catch (err) {
+    sdk.console.log(`fetchJxscoutStatus: ${err}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// Phase 5: binary discovery RPCs. detectBinary/validateBinary mirror
+// fetchJxscoutStatus -- they collapse failures into their own result types
+// rather than the Response<T> wrapper, so the frontend has a single shape to
+// render. The settings-mutating RPCs use Response<Settings> to match
+// saveSettings.
+const readCurrentSettings = async (sdk: SDK): Promise<Settings> => {
+  const response = await getSettings(sdk);
+  if (response.success) return response.data;
+  // getSettings already collapses every failure to defaults, but type-narrow
+  // for completeness so the RPC can't accidentally swallow a real error path.
+  return { ...DEFAULT_SETTINGS };
+};
+
+const detectBinaryHandler = async (sdk: SDK): Promise<DetectionResult> => {
+  const settings = await readCurrentSettings(sdk);
+  return await detectBinary(settings.customBinaryPath);
+};
+
+const validateBinaryHandler = async (
+  _sdk: SDK,
+  binaryPath: string
+): Promise<ValidationResult> => {
+  return await validateBinary(binaryPath);
+};
+
+const setCustomBinaryPathHandler = async (
+  sdk: SDK,
+  binaryPath: string
+): Promise<Response<Settings>> => {
+  if (typeof binaryPath !== "string" || binaryPath.trim().length === 0) {
+    return error("Custom binary path cannot be empty");
+  }
+  const current = await readCurrentSettings(sdk);
+  return await saveSettings(sdk, {
+    ...current,
+    customBinaryPath: binaryPath.trim(),
+  });
+};
+
+const clearCustomBinaryPathHandler = async (
+  sdk: SDK
+): Promise<Response<Settings>> => {
+  const current = await readCurrentSettings(sdk);
+  return await saveSettings(sdk, { ...current, customBinaryPath: null });
+};
+
+// Lowercase a-z0-9 + hyphen so the value passes muster as a project name on
+// the jxscout side (which writes it into a project directory). Shared between
+// the start-args resolver and Phase 8's auto-sync handler so both code paths
+// agree on the canonical form.
+const normalizeProjectName = (raw: string): string => {
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "caido";
+};
+
+// Phase 6 supervisor handlers. Mutator RPCs (start/stop/restart) use the
+// supervisor's own result types -- they're typed-result, not Response<T>,
+// because the supervisor needs to surface the pid/port from a successful
+// start (not just "ok"). Query-style RPCs (getSupervisorState) collapse
+// failures to a snapshot, matching the Phase 5 contract for detectBinary.
+const resolveStartArgs = async (
+  sdk: SDK
+): Promise<
+  { ok: true; binaryPath: string; project: string; port: number; defaultProjectsDir: string | null }
+  | { ok: false; error: string }
+> => {
+  const settings = await readCurrentSettings(sdk);
+
+  const detection = await detectBinary(settings.customBinaryPath);
+  if (detection.source === null) {
+    return {
+      ok: false,
+      error:
+        "jxscout-pro-v2 binary not found (custom path / PATH / managed install all empty)",
+    };
+  }
+
+  // Phase 10 manual project override. Only honored when autoSync is off --
+  // when on, the Phase 8 onProjectChange handler is the authority and we
+  // always follow Caido's current project. We normalize here so a free-form
+  // name typed in the picker (e.g. "My Project") canonicalises to the same
+  // slug the supervisor would have used. The override lives in module-scope
+  // state (not settings.json) so parallel Caido processes sharing the same
+  // Data dir can each pick their own manual project independently.
+  let finalProject: string;
+  if (settings.autoSync === false && typeof inMemoryManualProjectName === "string") {
+    const overrideRaw = inMemoryManualProjectName.trim();
+    if (overrideRaw.length > 0) {
+      finalProject = normalizeProjectName(overrideRaw);
+    } else {
+      finalProject = "";
+    }
+  } else {
+    finalProject = "";
+  }
+
+  if (finalProject.length === 0) {
+    const projectFromCaido = await sdk.projects.getCurrent();
+    const projectName =
+      projectFromCaido && typeof projectFromCaido.getName() === "string"
+        ? projectFromCaido.getName().trim()
+        : "";
+    if (projectName.length === 0) {
+      return {
+        ok: false,
+        error: "No active Caido project; open one before starting Managed mode",
+      };
+    }
+    finalProject = normalizeProjectName(projectName);
+  }
+
+  // Port allocation. The managed port is STICKY for this Caido process's
+  // lifetime -- once chosen we reuse it for every start / restart / project
+  // switch. We deliberately ignore settings.port (the manual-mode connection
+  // target, not a managed-mode preference).
+  //
+  // Why sticky: resolveStartArgs runs BEFORE restartJxscout stops the old
+  // process, so a fresh findFreePort(3333) probe on every call would skip
+  // past our own still-bound port and creep upward on each restart (and
+  // project switch, which restarts too). The user connects to a port that
+  // keeps changing out from under them -- bad UX.
+  //
+  // Reuse rules:
+  //   - supervisor live (running/starting): reuse its port verbatim. It's
+  //     ours, and the stop that precedes the restart frees it before we
+  //     rebind.
+  //   - otherwise (fresh start / after stop): probe from the remembered port
+  //     so we land on it again if it's free, only walking past it if a
+  //     foreign process grabbed it while we were down.
+  // Parallel Caido instances each keep their own cache (module scope), so the
+  // first probe still spreads them across distinct ports.
+  const MANAGED_BASE_PORT = 3333;
+  const snap = getSupervisorState();
+  let port: number | null;
+  if (
+    (snap.state === "running" || snap.state === "starting") &&
+    typeof snap.port === "number" &&
+    Number.isFinite(snap.port) &&
+    snap.port > 0
+  ) {
+    port = snap.port;
+  } else {
+    const preferred = managedPort ?? MANAGED_BASE_PORT;
+    port = await findFreePort(preferred);
+    if (port === null) {
+      return {
+        ok: false,
+        error: `No free port in [${preferred}, ${preferred + 49}]`,
+      };
+    }
+    if (port !== preferred) {
+      sdk.console.log(
+        `supervisor: preferred port ${preferred} busy, using ${port} this session`
+      );
+    }
+  }
+  managedPort = port;
+
+  return {
+    ok: true,
+    binaryPath: detection.path,
+    project: finalProject,
+    port,
+    defaultProjectsDir: settings.defaultProjectsDir,
+  };
+};
+
+// Module-scope per-Caido-process state. Intentionally not persisted to
+// settings.json (which is shared across parallel Caido instances sharing
+// the same Data dir). The Phase 10 manual project override lives here so
+// each Caido can pick its own without trampling siblings.
+let inMemoryManualProjectName: string | null = null;
+
+// Sticky managed port for this Caido process. Set on first start, then reused
+// across every restart / project switch so the port the user connects to
+// doesn't creep upward (see the port-allocation note in resolveStartArgs).
+// Per-process (module scope) so parallel Caido instances keep distinct ports.
+let managedPort: number | null = null;
+
+const startJxscoutHandler = async (sdk: SDK): Promise<StartResult> => {
+  const args = await resolveStartArgs(sdk);
+  if (!args.ok) return { success: false, error: args.error };
+  return await startJxscoutFn(sdk, {
+    binaryPath: args.binaryPath,
+    project: args.project,
+    port: args.port,
+    defaultProjectsDir: args.defaultProjectsDir,
+  });
+};
+
+const stopJxscoutHandler = async (sdk: SDK): Promise<StopResult> => {
+  return await stopJxscoutFn(sdk);
+};
+
+const restartJxscoutHandler = async (sdk: SDK): Promise<StartResult> => {
+  const args = await resolveStartArgs(sdk);
+  if (!args.ok) return { success: false, error: args.error };
+  return await restartJxscoutFn(sdk, {
+    binaryPath: args.binaryPath,
+    project: args.project,
+    port: args.port,
+    defaultProjectsDir: args.defaultProjectsDir,
+  });
+};
+
+const getSupervisorStateHandler = async (
+  _sdk: SDK
+): Promise<SupervisorSnapshot> => {
+  return getSupervisorState();
+};
+
+// Phase 7 download flow. Resolves the v2 endpoint, fetches the archive, and
+// installs the binary at ~/.jxscout-pro/bin/jxscout-pro-v2[.exe]. Progress
+// arrives on the frontend via the "download-progress" event. Mutator-style
+// result type per the Phase 5/6 convention (collapses failures into the
+// typed result rather than Response<T>).
+const downloadBinaryHandler = async (sdk: SDK): Promise<DownloadResult> => {
+  return await downloadBinaryFn(sdk);
+};
+
+// Lets the frontend show the right platform label on the BIN-1 card and the
+// "Unsupported platform" hard-fail case before the user clicks Download.
+const getReleaseTypeHandler = async (
+  _sdk: SDK
+): Promise<ReleaseType | null> => {
+  return releaseTypeForCurrentPlatform();
+};
+
+// ---------------------------------------------------------------------------
+// Phase 10: manual project picker (auto-sync off)
+// ---------------------------------------------------------------------------
+
+const PROJECTS_FETCH_TIMEOUT_MS = 1500;
+
+// Effective port mirrors useJxscoutStatus on the frontend: prefer the live
+// session port if the supervisor is up, otherwise the persisted preference.
+// Same fallback shape as fetchJxscoutStatus's callsite.
+const effectivePort = (settings: Settings): number => {
+  const snap = getSupervisorState();
+  if (
+    snap.state === "running" &&
+    typeof snap.port === "number" &&
+    Number.isFinite(snap.port) &&
+    snap.port > 0
+  ) {
+    return snap.port;
+  }
+  return Number.isFinite(settings.port) && settings.port > 0
+    ? settings.port
+    : 3333;
+};
+
+// Returns null when the supervisor isn't running OR jxscout-rs doesn't answer.
+// The frontend uses null as a single "(jxscout not responding)" signal -- same
+// convention as fetchJxscoutStatus.
+//
+// AbortController + setTimeout (not AbortSignal.timeout()) per the Phase 4
+// LLRT gotcha: the latter crashed caido-cli when fetch failed with
+// ECONNREFUSED.
+const listJxscoutProjectsHandler = async (
+  sdk: SDK
+): Promise<ProjectEntry[] | null> => {
+  const settings = await readCurrentSettings(sdk);
+  const snap = getSupervisorState();
+
+  // If the supervisor's not running, hitting settings.port could either fail
+  // (no jxscout) or hit some OTHER process on that port. Either way we don't
+  // have a trustworthy answer to render in the picker.
+  if (snap.state !== "running") {
+    return null;
+  }
+
+  const port = effectivePort(settings);
+  const host =
+    typeof settings.host === "string" && settings.host.trim().length > 0
+      ? settings.host
+      : "localhost";
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    try {
+      controller.abort();
+    } catch {
+      // swallow
+    }
+  }, PROJECTS_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`http://${host}:${port}/projects`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const raw = (await response.json()) as unknown;
+    if (!Array.isArray(raw)) {
+      return null;
+    }
+    const out: ProjectEntry[] = [];
+    for (const item of raw) {
+      if (!item || typeof item !== "object") continue;
+      const obj = item as Record<string, unknown>;
+      if (typeof obj.name !== "string" || typeof obj.path !== "string") continue;
+      out.push({ name: obj.name, path: obj.path });
+    }
+    return out;
+  } catch (err) {
+    sdk.console.log(`listJxscoutProjects: ${err}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Scope push: relay host patterns to jxscout's POST /scope endpoint. Called
+// by the frontend's Save button only. Scope is per-project on the jxscout
+// side, so the plugin no longer caches patterns in its own settings or
+// re-pushes them on supervisor start -- doing so used to clobber a new
+// project's scope with the previous project's patterns on every project
+// switch. The frontend now fetches scope via GET /scope after each supervisor
+// start to populate the UI.
+//
+// AbortController + manual setTimeout (not AbortSignal.timeout()) per the
+// Phase 4 LLRT gotcha that crashed caido-cli on ECONNREFUSED.
+const pushScopeHandler = async (
+  sdk: SDK,
+  payload: { in_scope: string[]; out_of_scope: string[] }
+): Promise<Response<null>> => {
+  const settings = await readCurrentSettings(sdk);
+  const snap = getSupervisorState();
+  // Don't try to push when there's no supervisor to receive the call. The
+  // frontend re-pushes on the next supervisor-start anyway, so dropping the
+  // call here just avoids a spurious ECONNREFUSED toast.
+  if (snap.state !== "running") {
+    return ok(null);
+  }
+
+  const port = effectivePort(settings);
+  const host =
+    typeof settings.host === "string" && settings.host.trim().length > 0
+      ? settings.host
+      : "localhost";
+
+  // Defensive: trim + drop empties on the way out. jxscout-rs's set_scope
+  // handler does the same normalization, but doing it here too keeps the
+  // wire payload tidy (e.g. easier to diff in logs).
+  const normalize = (xs: unknown): string[] =>
+    Array.isArray(xs)
+      ? xs
+          .filter((v): v is string => typeof v === "string")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : [];
+  const body = {
+    in_scope: normalize(payload?.in_scope),
+    out_of_scope: normalize(payload?.out_of_scope),
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    try {
+      controller.abort();
+    } catch {
+      // swallow
+    }
+  }, SCOPE_PUSH_TIMEOUT_MS);
+
+  try {
+    // Caido's quickjs runtime types `body` as `Blob` (see
+    // @caido/quickjs-types/src/caido/http.d.ts:151), not `string` like the DOM
+    // fetch -- wrap the JSON in a Blob so the typecheck passes and the
+    // content-type is honored.
+    const response = await fetch(`http://${host}:${port}/scope`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: new Blob([JSON.stringify(body)], { type: "application/json" }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      return error(
+        `jxscout /scope returned ${response.status}${
+          detail ? `: ${detail.slice(0, 200)}` : ""
+        }`
+      );
+    }
+    sdk.console.log(
+      `pushScope: in_scope=${body.in_scope.length} out_of_scope=${body.out_of_scope.length}`
+    );
+    return ok(null);
+  } catch (err) {
+    sdk.console.error(`pushScope failed: ${err}`);
+    return error(`pushScope failed: ${err}`);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Scope fetch: read the live scope from jxscout's GET /scope so the frontend
+// can populate its textareas with whichever patterns the *current* project
+// has on disk. Called on every supervisor->running transition (incl. project
+// switch). Same AbortController pattern as pushScopeHandler.
+const fetchScopeHandler = async (
+  sdk: SDK
+): Promise<Response<{ in_scope: string[]; out_of_scope: string[] }>> => {
+  const settings = await readCurrentSettings(sdk);
+  const snap = getSupervisorState();
+  // No supervisor -> nothing to read. Return empty arrays rather than an
+  // error so the frontend can just clear its textareas.
+  if (snap.state !== "running") {
+    return ok({ in_scope: [], out_of_scope: [] });
+  }
+
+  const port = effectivePort(settings);
+  const host =
+    typeof settings.host === "string" && settings.host.trim().length > 0
+      ? settings.host
+      : "localhost";
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    try {
+      controller.abort();
+    } catch {
+      // swallow
+    }
+  }, SCOPE_PUSH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`http://${host}:${port}/scope`, {
+      method: "GET",
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      return error(
+        `jxscout GET /scope returned ${response.status}${
+          detail ? `: ${detail.slice(0, 200)}` : ""
+        }`
+      );
+    }
+    const raw = (await response.json()) as unknown;
+    const normalize = (xs: unknown): string[] =>
+      Array.isArray(xs)
+        ? xs
+            .filter((v): v is string => typeof v === "string")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+        : [];
+    const obj =
+      raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+    const data = {
+      in_scope: normalize(obj.in_scope),
+      out_of_scope: normalize(obj.out_of_scope),
+    };
+    sdk.console.log(
+      `fetchScope: in_scope=${data.in_scope.length} out_of_scope=${data.out_of_scope.length}`
+    );
+    return ok(data);
+  } catch (err) {
+    sdk.console.error(`fetchScope failed: ${err}`);
+    return error(`fetchScope failed: ${err}`);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Open a filesystem path in an external tool (file manager / VS Code / Cursor).
+//
+// `tool` decides the launcher; the path is passed as the last arg verbatim so
+// we don't need shell quoting. Tools other than "folder" rely on the user
+// having `code` / `cursor` on PATH (both editors expose a CLI helper from
+// their command palette). When the binary is missing the spawn 'error' event
+// fires asynchronously -- we attach a listener so the error makes it to the
+// plugin log instead of crashing the runtime.
+//
+// LLRT's SpawnOptions omits `detached` and ChildProcess has no `.unref()`,
+// so we can't formally detach. In practice the platform launchers (`open`,
+// `xdg-open`, `explorer`) and the editor CLI helpers exit milliseconds after
+// the target window opens, so the spawned process doesn't outlive the RPC.
+// ---------------------------------------------------------------------------
+
+type OpenTool = "folder" | "vscode" | "cursor";
+
+const resolveOpenCommand = (
+  tool: OpenTool
+): { cmd: string; args: readonly string[] } | null => {
+  switch (tool) {
+    case "folder": {
+      const platform = os.platform();
+      if (platform === "darwin") return { cmd: "open", args: [] };
+      if (platform === "win32") return { cmd: "explorer", args: [] };
+      // Linux + BSDs: xdg-open is the freedesktop standard; ships with
+      // virtually every desktop distro.
+      return { cmd: "xdg-open", args: [] };
+    }
+    case "vscode":
+      return { cmd: "code", args: [] };
+    case "cursor":
+      return { cmd: "cursor", args: [] };
+  }
+};
+
+const openPathHandler = async (
+  sdk: SDK,
+  payload: { path: string; tool: OpenTool }
+): Promise<Response<null>> => {
+  if (
+    typeof payload?.path !== "string" ||
+    payload.path.trim().length === 0
+  ) {
+    return error("Empty path");
+  }
+  const resolved = resolveOpenCommand(payload.tool);
+  if (!resolved) {
+    return error(`Unsupported tool: ${payload.tool}`);
+  }
+
+  try {
+    const child = spawn(resolved.cmd, [...resolved.args, payload.path], {
+      stdio: "ignore",
+    });
+    child.on("error", (err: Error) => {
+      sdk.console.error(
+        `openPath(${payload.tool}) spawn error: ${err.message ?? String(err)}`
+      );
+    });
+    return ok(null);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    sdk.console.error(`openPath(${payload.tool}) failed: ${message}`);
+    return error(`Failed to launch ${payload.tool}: ${message}`);
+  }
+};
+
+// Stores the manual override in module-scope memory; the frontend explicitly
+// calls restartJxscout afterwards when it wants the supervisor to rebind.
+// Splitting save and restart keeps the RPC composable -- a future "save the
+// override but don't restart" flow (e.g. setting it before first Start) Just
+// Works. The value is intentionally not persisted: it's per-Caido-instance
+// state (and parallel Caido processes might each want a different project).
+const setManualProjectHandler = async (
+  _sdk: SDK,
+  name: string | null
+): Promise<Response<{ manualProjectName: string | null }>> => {
+  const next: string | null =
+    typeof name === "string" && name.trim().length > 0 ? name.trim() : null;
+  inMemoryManualProjectName = next;
+  return ok({ manualProjectName: next });
+};
+
+const getManualProjectHandler = async (
+  _sdk: SDK
+): Promise<Response<{ manualProjectName: string | null }>> => {
+  return ok({ manualProjectName: inMemoryManualProjectName });
+};
+
+// ---------------------------------------------------------------------------
+// Phase 8: auto-launch + auto-sync
+// ---------------------------------------------------------------------------
+
+// Fired at the top of an auto-sync restart so the frontend can show a
+// "Switching project..." pill while the supervisor cycles through stopped ->
+// starting -> running. Also fired on the "project closed" path so the UI
+// can show a brief "Stopping..." indicator. Frontend hides the pill on the
+// next supervisor 'running' (or 'stopped') transition or after a ~1.5s
+// timeout, whichever fires first.
+export type AutoSyncEvent =
+  | { kind: "switching"; from: string | null; to: string }
+  | { kind: "stopping"; from: string | null };
+
+// sdk.api.send types against Spec.events. We use the same narrow cast as the
+// supervisor / download modules to avoid threading a generic everywhere. The
+// frontend's onEvent still type-checks against Spec["events"], which is the
+// contract that matters for consumers.
+type LooseSend = (event: string, ...args: unknown[]) => void;
+
+const emitAutoSync = (sdk: SDK, payload: AutoSyncEvent): void => {
+  try {
+    (sdk.api.send as unknown as LooseSend)("auto-sync", payload);
+  } catch (err) {
+    sdk.console.error(`jxscout-caido: failed to emit auto-sync event: ${err}`);
+  }
+};
+
+// Plugin-init auto-launch. Sequenced strictly after recoverOrphan(). Gated on
+// the full chain so a user who doesn't want this never has jxscout-pro-v2
+// uninvitedly spawn on every Caido start. Each guard logs a one-liner so the
+// reason for not auto-launching is debuggable from /tmp/caido-cli.log.
+const maybeAutoLaunch = async (sdk: SDK): Promise<void> => {
+  const settings = await readCurrentSettings(sdk);
+  if (settings.mode !== "managed") {
+    sdk.console.log("auto-launch: skipped (mode != managed)");
+    return;
+  }
+  if (!settings.autoLaunch) {
+    sdk.console.log("auto-launch: skipped (autoLaunch=false)");
+    return;
+  }
+  // No persisted "user clicked Stop last session" gate -- that state was
+  // moved out of settings.json. Within a single Caido process the user can
+  // still click Stop and the supervisor stays stopped; across Caido restarts
+  // auto-launch fires whenever the other gates pass, on the principle that
+  // a fresh Caido session shouldn't inherit a previous session's pause.
+  const pro = await hasLicenseFile();
+  if (!pro) {
+    sdk.console.log("auto-launch: skipped (no license)");
+    return;
+  }
+  const detection = await detectBinary(settings.customBinaryPath);
+  if (detection.source === null) {
+    sdk.console.log("auto-launch: skipped (binary not detected)");
+    return;
+  }
+
+  sdk.console.log(
+    `auto-launch: starting jxscout-pro-v2 (binary=${detection.path})`
+  );
+  const result = await startJxscoutHandler(sdk);
+  if (!result.success) {
+    sdk.console.error(`auto-launch: failed: ${result.error}`);
+  } else {
+    sdk.console.log(
+      `auto-launch: running (pid=${result.pid}, port=${result.port})`
+    );
+  }
+};
+
+// onProjectChange handler. Per Phase 8 plan:
+//   - Skip if not managed / autoSync off / supervisor not running.
+//   - project === null (Caido project closed): stop jxscout.
+//   - project !== null: if normalized name differs from supervisor.project,
+//     restart with --project-name=<new>. Emits "auto-sync" event so the
+//     frontend can render a transient "Switching project..." pill.
+type CaidoProject = {
+  getName(): string;
+} | null;
+
+const maybeAutoSync = async (
+  sdk: SDK,
+  project: CaidoProject
+): Promise<void> => {
+  const settings = await readCurrentSettings(sdk);
+  if (settings.mode !== "managed") return;
+  if (!settings.autoSync) return;
+
+  const snap = getSupervisorState();
+  if (snap.state !== "running" && snap.state !== "starting") {
+    // Don't spawn via auto-sync; auto-launch's job. Don't reach into a failed
+    // supervisor either -- that's the user's call (Retry button).
+    return;
+  }
+
+  // Caido project closed. Stop the supervised jxscout per the Phase 8
+  // resolution ("Stop jxscout when project closes"). Persist intent='stopped'
+  // so a future re-open doesn't auto-launch back into the *previous* project's
+  // jxscout -- the user has to either reopen the same project (and click
+  // Start) or rely on auto-launch firing on the next Caido boot.
+  if (project === null) {
+    sdk.console.log("auto-sync: Caido project closed; stopping jxscout");
+    emitAutoSync(sdk, { kind: "stopping", from: snap.project });
+    await stopJxscoutHandler(sdk);
+    return;
+  }
+
+  const rawName = typeof project.getName === "function" ? project.getName() : "";
+  const desired = normalizeProjectName(rawName.trim());
+  if (snap.project !== null && snap.project === desired) {
+    // Same project after normalization -- no-op. Defends against onProjectChange
+    // firing redundantly (e.g. project metadata updated without a real switch).
+    return;
+  }
+
+  sdk.console.log(
+    `auto-sync: project change ${snap.project ?? "(none)"} -> ${desired}; restarting`
+  );
+  emitAutoSync(sdk, { kind: "switching", from: snap.project, to: desired });
+  const result = await restartJxscoutHandler(sdk);
+  if (!result.success) {
+    sdk.console.error(`auto-sync: restart failed: ${result.error}`);
+  }
+};
+
+export type Spec = DefinePluginPackageSpec<{
+  manifestId: "jxscout-caido";
+  api: {
+    saveSettings: (settings: Partial<Settings>) => Promise<Response<Settings>>;
+    getSettings: () => Promise<Response<Settings>>;
+    getLicense: () => Promise<Response<StoredLicense | null>>;
+    setLicense: (key: string) => Promise<Response<StoredLicense>>;
+    clearLicense: () => Promise<Response<null>>;
+    hasLicense: () => Promise<Response<boolean>>;
+    fetchJxscoutStatus: (
+      host: string,
+      port: number
+    ) => Promise<JxscoutStatus | null>;
+    detectBinary: () => Promise<DetectionResult>;
+    validateBinary: (binaryPath: string) => Promise<ValidationResult>;
+    setCustomBinaryPath: (binaryPath: string) => Promise<Response<Settings>>;
+    clearCustomBinaryPath: () => Promise<Response<Settings>>;
+    startJxscout: () => Promise<StartResult>;
+    stopJxscout: () => Promise<StopResult>;
+    restartJxscout: () => Promise<StartResult>;
+    getSupervisorState: () => Promise<SupervisorSnapshot>;
+    downloadBinary: () => Promise<DownloadResult>;
+    getReleaseType: () => Promise<ReleaseType | null>;
+    listJxscoutProjects: () => Promise<ProjectEntry[] | null>;
+    setManualProject: (
+      name: string | null
+    ) => Promise<Response<{ manualProjectName: string | null }>>;
+    getManualProject: () => Promise<
+      Response<{ manualProjectName: string | null }>
+    >;
+    pushScope: (payload: {
+      in_scope: string[];
+      out_of_scope: string[];
+    }) => Promise<Response<null>>;
+    fetchScope: () => Promise<
+      Response<{ in_scope: string[]; out_of_scope: string[] }>
+    >;
+    openPath: (payload: {
+      path: string;
+      tool: "folder" | "vscode" | "cursor";
+    }) => Promise<Response<null>>;
+  };
+  events: {
+    "supervisor-state": (snapshot: SupervisorSnapshot) => void;
+    "download-progress": (progress: DownloadProgress) => void;
+    "auto-sync": (event: AutoSyncEvent) => void;
+  };
 }>;
 
-export function init(sdk: SDK<API>) {
+export function init(sdk: SDK<Spec>) {
   sdk.api.register("saveSettings", saveSettings);
   sdk.api.register("getSettings", getSettings);
+  sdk.api.register("getLicense", getLicenseHandler);
+  sdk.api.register("setLicense", setLicenseHandler);
+  sdk.api.register("clearLicense", clearLicenseHandler);
+  sdk.api.register("hasLicense", hasLicenseHandler);
+  sdk.api.register("fetchJxscoutStatus", fetchJxscoutStatus);
+  sdk.api.register("detectBinary", detectBinaryHandler);
+  sdk.api.register("validateBinary", validateBinaryHandler);
+  sdk.api.register("setCustomBinaryPath", setCustomBinaryPathHandler);
+  sdk.api.register("clearCustomBinaryPath", clearCustomBinaryPathHandler);
+  sdk.api.register("startJxscout", startJxscoutHandler);
+  sdk.api.register("stopJxscout", stopJxscoutHandler);
+  sdk.api.register("restartJxscout", restartJxscoutHandler);
+  sdk.api.register("getSupervisorState", getSupervisorStateHandler);
+  sdk.api.register("downloadBinary", downloadBinaryHandler);
+  sdk.api.register("getReleaseType", getReleaseTypeHandler);
+  sdk.api.register("listJxscoutProjects", listJxscoutProjectsHandler);
+  sdk.api.register("setManualProject", setManualProjectHandler);
+  sdk.api.register("getManualProject", getManualProjectHandler);
+  sdk.api.register("pushScope", pushScopeHandler);
+  sdk.api.register("fetchScope", fetchScopeHandler);
+  sdk.api.register("openPath", openPathHandler);
+
+  // Phase 6 orphan recovery: if a previous Caido instance crashed while
+  // jxscout was running, the child can survive plugin teardown. Read the
+  // pid file, SIGTERM if alive, clean up.
+  //
+  // Phase 8: after orphan recovery, optionally auto-launch. Gated on a full
+  // chain so a user who switched to Manual, disabled autoLaunch, removed their
+  // license, deleted the binary, OR explicitly clicked Stop most recently does
+  // NOT have their machine spawn jxscout uninvitedly on every Caido start.
+  // Sequenced strictly after orphan recovery -- otherwise we'd race with
+  // SIGTERM-and-pid-file cleanup, and the fresh spawn could land on the same
+  // port the orphan was still releasing.
+  void (async () => {
+    try {
+      await recoverOrphan(sdk);
+    } catch (err) {
+      sdk.console.error(`jxscout-caido: orphan recovery failed: ${err}`);
+    }
+    try {
+      await maybeAutoLaunch(sdk);
+    } catch (err) {
+      sdk.console.error(`jxscout-caido: auto-launch attempt failed: ${err}`);
+    }
+  })();
+
+  // Phase 8 auto-sync: follow the Caido project. Skip when not in managed
+  // mode, when the user has disabled the toggle, or when the supervisor isn't
+  // running (i.e. we don't accidentally start jxscout via auto-sync -- that's
+  // auto-launch's job).
+  sdk.events.onProjectChange(async (eventSdk, project) => {
+    try {
+      await maybeAutoSync(eventSdk, project);
+    } catch (err) {
+      eventSdk.console.error(`jxscout-caido: auto-sync failed: ${err}`);
+    }
+  });
 
   sdk.events.onInterceptResponse(async (sdk, request, response) => {
     if (!globalSettings) {
@@ -79,7 +1112,7 @@ export function init(sdk: SDK<API>) {
         sdk.console.error(
           `jxscout-caido: failed to load settings ${settingsResponse.error}`
         );
-        globalSettings = DEFAULT_SETTINGS;
+        globalSettings = { ...DEFAULT_SETTINGS };
       }
     }
 
@@ -89,9 +1122,28 @@ export function init(sdk: SDK<API>) {
       return;
     }
 
-    const requestSpec = new RequestSpec("http://" + settings.host);
+    // Pick the right ingest endpoint at fire time, not from cached
+    // settings.json. When the supervisor is running (managed mode active),
+    // jxscout is bound to 127.0.0.1 on a port the plugin discovered at
+    // start -- live in snap, not in settings, because parallel Caido
+    // instances each pick their own port. When the supervisor isn't
+    // running we assume manual mode and use the user-configured target.
+    const snap = getSupervisorState();
+    const isLiveManaged =
+      snap.state === "running" &&
+      typeof snap.port === "number" &&
+      Number.isFinite(snap.port) &&
+      snap.port > 0;
+    const port = isLiveManaged ? snap.port! : settings.port;
+    const host = isLiveManaged
+      ? "127.0.0.1"
+      : typeof settings.host === "string" && settings.host.trim().length > 0
+        ? settings.host
+        : "localhost";
+
+    const requestSpec = new RequestSpec("http://" + host);
     requestSpec.setPath("/caido-ingest");
-    requestSpec.setPort(settings.port);
+    requestSpec.setPort(port);
     requestSpec.setMethod("POST");
     requestSpec.setHeader("content-type", "application/json");
     requestSpec.setBody(

--- a/packages/backend/src/license.ts
+++ b/packages/backend/src/license.ts
@@ -1,0 +1,80 @@
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { StoredLicense } from "./types";
+
+const LICENSE_DIR_NAME = ".jxscout-pro";
+const LICENSE_FILE_NAME = ".license";
+
+export const licensePath = (): string =>
+    path.join(os.homedir(), LICENSE_DIR_NAME, LICENSE_FILE_NAME);
+
+export const readLicense = async (): Promise<StoredLicense | null> => {
+    let raw: string;
+    try {
+        raw = await readFile(licensePath(), "utf-8");
+    } catch {
+        return null;
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+
+    if (!parsed || typeof parsed !== "object") {
+        return null;
+    }
+    const obj = parsed as Record<string, unknown>;
+
+    if (typeof obj.license_key !== "string" || obj.license_key.length === 0) {
+        return null;
+    }
+
+    const machineFingerprint =
+        typeof obj.machine_fingerprint === "string" ? obj.machine_fingerprint : null;
+
+    return {
+        license_key: obj.license_key,
+        machine_fingerprint: machineFingerprint,
+    };
+};
+
+export const writeLicense = async (key: string): Promise<void> => {
+    const trimmed = key.trim();
+    if (trimmed.length === 0) {
+        throw new Error("License key cannot be empty");
+    }
+
+    const filePath = licensePath();
+    const dir = path.dirname(filePath);
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+
+    // Preserve machine_fingerprint when the key is unchanged so jxscout-pro-v2
+    // doesn't have to re-validate via Keygen. Reset to null on a key change.
+    let machineFingerprint: string | null = null;
+    const existing = await readLicense();
+    if (existing && existing.license_key === trimmed) {
+        machineFingerprint = existing.machine_fingerprint;
+    }
+
+    const payload: StoredLicense = {
+        license_key: trimmed,
+        machine_fingerprint: machineFingerprint,
+    };
+
+    await writeFile(filePath, JSON.stringify(payload), { mode: 0o600 });
+};
+
+export const clearLicense = async (): Promise<void> => {
+    // `force: true` makes rm a no-op when the file is already missing.
+    await rm(licensePath(), { force: true });
+};
+
+export const hasLicense = async (): Promise<boolean> => {
+    const license = await readLicense();
+    return license !== null;
+};

--- a/packages/backend/src/supervisor.ts
+++ b/packages/backend/src/supervisor.ts
@@ -1,0 +1,985 @@
+import type { SDK } from "caido:plugin";
+import { fetch } from "caido:http";
+import type { ChildProcess } from "child_process";
+import { spawn } from "child_process";
+import { mkdir, readdir, readFile, rm, writeFile } from "fs/promises";
+import * as net from "net";
+import * as os from "os";
+import * as path from "path";
+
+import { validateBinary } from "./binary";
+
+// PID-file isolation per Caido plugin process. Multiple Caido instances can
+// share the same Data dir (i.e. the same sdk.meta.path()) and concurrently
+// run their own jxscout supervisors. Keying the pid file by the LLRT plugin
+// process's pid stops cross-instance orphan recovery from SIGTERMing a
+// sibling Caido's still-running jxscout.
+//
+// Layout under ${sdk.meta.path()}/:
+//   managed-pids/<caido-llrt-pid>.pid   -- content: jxscout's pid
+const MANAGED_PIDS_DIR = "managed-pids";
+
+const HEALTH_POLL_INTERVAL_MS = 200;
+const HEALTH_POLL_TIMEOUT_MS = 5000;
+const HEALTH_FETCH_TIMEOUT_MS = 500;
+const STOP_GRACE_MS = 3000;
+const ORPHAN_GRACE_MS = 2000;
+// Keep enough of jxscout's stderr to surface the actual failure (e.g. SQLite
+// lock errors, port-bind panics) when the process exits non-zero. 2KB is
+// plenty for one or two stack frames + the error message; large enough to
+// be useful, small enough to fit in a UI toast.
+const STDERR_TAIL_BYTES = 2048;
+
+const DEFAULT_PORT = 3333;
+const PORT_PROBE_RANGE = 50; // 3333..3382
+
+export type SupervisorStateName =
+  | "stopped"
+  | "starting"
+  | "running"
+  | "failed";
+
+export type SupervisorSnapshot = {
+  state: SupervisorStateName;
+  pid: number | null;
+  port: number | null;
+  startedAt: number | null;
+  lastError: string | null;
+  manuallyStopped: boolean;
+  // Phase 8: the normalized project name the supervisor was spawned with.
+  // Auto-sync compares against this on `onProjectChange` so a re-fire with the
+  // same value doesn't trigger a no-op restart. Null when stopped.
+  project: string | null;
+};
+
+export type SupervisorEvents = {
+  "supervisor-state": (snapshot: SupervisorSnapshot) => void;
+};
+
+export type StartArgs = {
+  binaryPath: string;
+  project: string;
+  port: number;
+  defaultProjectsDir?: string | null;
+};
+
+// Module-scope mutable state. The supervisor is a singleton per plugin
+// install -- there's no meaningful "two managed jxscouts" use case.
+// `manuallyStopped` lives here (not in settings.json) so a plugin reload
+// resets it: a crashed Caido shouldn't trap the user in "stopped" forever
+// across restarts (confirmed Phase 6 decision).
+type InternalState = SupervisorSnapshot & {
+  child: ChildProcess | null;
+  closeWaiters: Array<() => void>;
+  healthAbort: AbortController | null;
+};
+
+const state: InternalState = {
+  state: "stopped",
+  pid: null,
+  port: null,
+  startedAt: null,
+  lastError: null,
+  manuallyStopped: false,
+  project: null,
+  child: null,
+  closeWaiters: [],
+  healthAbort: null,
+};
+
+const snapshot = (): SupervisorSnapshot => ({
+  state: state.state,
+  pid: state.pid,
+  port: state.port,
+  startedAt: state.startedAt,
+  lastError: state.lastError,
+  manuallyStopped: state.manuallyStopped,
+  project: state.project,
+});
+
+export const getSupervisorState = (): SupervisorSnapshot => snapshot();
+
+// ---------------------------------------------------------------------------
+// PID file helpers
+// ---------------------------------------------------------------------------
+
+const managedPidsDirPath = (sdk: SDK): string =>
+  path.join(sdk.meta.path(), MANAGED_PIDS_DIR);
+
+// Names the pid file after THIS Caido backend process's pid (see getOwnPid).
+// When the pid is unknown (non-POSIX / lookup failure, getOwnPid -> 0) we fall
+// back to a non-numeric sentinel so orphan recovery's `parseInt(owner)` yields
+// NaN and skips it rather than mistaking it for a live foreign pid.
+const ownPidFilePath = async (sdk: SDK): Promise<string> => {
+  const pid = await getOwnPid();
+  const owner = pid > 0 ? String(pid) : "unknown";
+  return path.join(managedPidsDirPath(sdk), `${owner}.pid`);
+};
+
+const writePidFile = async (sdk: SDK, jxscoutPid: number): Promise<void> => {
+  await mkdir(managedPidsDirPath(sdk), { recursive: true, mode: 0o700 });
+  await writeFile(await ownPidFilePath(sdk), String(jxscoutPid), {
+    mode: 0o600,
+  });
+};
+
+const deletePidFile = async (sdk: SDK): Promise<void> => {
+  try {
+    // fs/promises in LLRT lacks `unlink`. `rm({force:true})` treats ENOENT as
+    // a no-op which is exactly what we want -- the file may already be gone
+    // (clean stop, orphan recovery, etc.).
+    await rm(await ownPidFilePath(sdk), { force: true });
+  } catch (err) {
+    sdk.console.error(`supervisor: failed to delete pid file: ${err}`);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// External-process liveness + signalling
+//
+// LLRT's `process` module doesn't expose `process.kill(pid, sig)` (the
+// `process` type only re-exports QuickJS.Signals -- see Phase 5 gotchas), so
+// we shell out via `kill(1)` / `taskkill(1)`. spawn-without-shell, args as an
+// array, runOnce-style settle on 'close'.
+// ---------------------------------------------------------------------------
+
+type ShortSpawnResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  error: string | null;
+};
+
+const runShort = (
+  cmd: string,
+  args: readonly string[],
+  timeoutMs: number
+): Promise<ShortSpawnResult> => {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    let stdout = "";
+    let stderr = "";
+
+    let child: ChildProcess;
+    try {
+      child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch (err) {
+      resolve({
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        error: String(err),
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // swallow
+      }
+    }, timeoutMs);
+
+    const settle = (exitCode: number | null, errString: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode, stdout, stderr, timedOut, error: errString });
+    };
+
+    child.stdout?.on("data", (chunk: unknown) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk: unknown) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err: Error) => {
+      settle(null, err.message ?? String(err));
+    });
+    child.on("close", (code: number | null) => {
+      settle(code, null);
+    });
+  });
+};
+
+const isPidAlive = async (pid: number): Promise<boolean> => {
+  if (os.platform() === "win32") {
+    // `tasklist` with a PID filter; exit 0 + stdout containing the pid line.
+    const r = await runShort(
+      "tasklist",
+      ["/FI", `PID eq ${pid}`, "/NH"],
+      2000
+    );
+    return r.exitCode === 0 && r.stdout.includes(String(pid));
+  }
+  // POSIX: kill -0 <pid> returns 0 if the process exists and we can signal
+  // it, 1 otherwise. No actual signal is sent.
+  const r = await runShort("kill", ["-0", String(pid)], 1000);
+  return r.exitCode === 0;
+};
+
+const signalPid = async (
+  pid: number,
+  signal: "TERM" | "KILL"
+): Promise<void> => {
+  if (os.platform() === "win32") {
+    // SIGTERM has no POSIX semantics on Windows; taskkill /F is the only
+    // reliable kill. Acceptable for orphan recovery -- the orphan is
+    // already detached.
+    await runShort("taskkill", ["/PID", String(pid), "/F"], 2000);
+    return;
+  }
+  await runShort("kill", [`-${signal}`, String(pid)], 1000);
+};
+
+// Our own pid -- the Caido backend process. Caido's QuickJS runtime provides
+// NO `process` global (a bare `process.pid` throws "process is not defined")
+// and does NOT register an importable `process` module (a static `import ...
+// from "process"` fails to link and takes the whole backend down). So we can't
+// ask the runtime directly. Instead we derive it: a child shell's $PPID is, by
+// definition, this process. Resolved once and cached.
+//
+// POSIX-only. On Windows (no `sh`/$PPID) or any failure we return 0; callers
+// degrade gracefully -- the pid file gets a non-numeric name and the jxscout
+// `--parent-pid` watchdog is omitted, leaving orphan recovery + explicit stop
+// as the backstops.
+let ownPidPromise: Promise<number> | null = null;
+const getOwnPid = (): Promise<number> => {
+  if (ownPidPromise === null) {
+    ownPidPromise = (async (): Promise<number> => {
+      if (os.platform() === "win32") return 0;
+      const r = await runShort("sh", ["-c", "echo $PPID"], 1000);
+      const pid = parseInt(r.stdout.trim(), 10);
+      return Number.isFinite(pid) && pid > 0 ? pid : 0;
+    })();
+  }
+  return ownPidPromise;
+};
+
+// ---------------------------------------------------------------------------
+// Port allocation
+// ---------------------------------------------------------------------------
+
+// Returns true if a listener can bind 127.0.0.1:port right now. Uses net so
+// we can actually verify bindability rather than relying on connect-probing
+// (which only detects something already serving on that port, not a port
+// that's reserved by another process but not yet listening).
+const portIsFree = (port: number): Promise<boolean> => {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (free: boolean) => {
+      if (settled) return;
+      settled = true;
+      try {
+        server.close();
+      } catch {
+        // swallow
+      }
+      resolve(free);
+    };
+
+    let server: net.Server;
+    try {
+      server = net.createServer();
+    } catch {
+      resolve(false);
+      return;
+    }
+    server.once("error", () => settle(false));
+    server.once("listening", () => settle(true));
+    try {
+      server.listen(port, "127.0.0.1");
+    } catch {
+      settle(false);
+    }
+  });
+};
+
+// First free port starting at `start`, scanning at most PORT_PROBE_RANGE
+// slots. Returns null if every slot is busy. Caller persists the result.
+export const findFreePort = async (
+  start: number = DEFAULT_PORT
+): Promise<number | null> => {
+  const base = Number.isFinite(start) && start > 0 ? Math.floor(start) : DEFAULT_PORT;
+  for (let i = 0; i < PORT_PROBE_RANGE; i++) {
+    const candidate = base + i;
+    if (candidate > 65535) break;
+    if (await portIsFree(candidate)) return candidate;
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// State transitions + event emission
+// ---------------------------------------------------------------------------
+
+// Plan calls for emitting only on state-name transitions. Patches that
+// accompany a transition (pid, port, startedAt, lastError) are bundled into
+// the same event; standalone patches without a state change don't fire.
+// SDK<API, Events> defaults to empty maps, so `sdk.api.send` only types in
+// the parent Spec (index.ts). The supervisor lives a layer below and would
+// either need a circular import or a duplicated Spec generic to get the
+// strictly-typed call. Casting once here is the smallest fix; the event
+// name + payload are still type-checked against SupervisorEvents at the
+// frontend's `onEvent` callsite, which is where the contract actually
+// needs to hold for consumers.
+type LooseSend = (event: string, ...args: unknown[]) => void;
+
+const emitState = (sdk: SDK, snap: SupervisorSnapshot): void => {
+  try {
+    (sdk.api.send as unknown as LooseSend)("supervisor-state", snap);
+  } catch (err) {
+    sdk.console.error(`supervisor: failed to emit state: ${err}`);
+  }
+};
+
+const transition = (
+  sdk: SDK,
+  next: SupervisorStateName,
+  patch: Partial<SupervisorSnapshot> = {}
+): void => {
+  const prev = state.state;
+
+  if ("pid" in patch) state.pid = patch.pid ?? null;
+  if ("port" in patch) state.port = patch.port ?? null;
+  if ("startedAt" in patch) state.startedAt = patch.startedAt ?? null;
+  if ("lastError" in patch) state.lastError = patch.lastError ?? null;
+  if ("manuallyStopped" in patch) {
+    state.manuallyStopped = patch.manuallyStopped ?? false;
+  }
+  if ("project" in patch) state.project = patch.project ?? null;
+
+  if (prev === next) return;
+  state.state = next;
+  sdk.console.log(`supervisor: ${prev} -> ${next}`);
+  emitState(sdk, snapshot());
+};
+
+const resolveCloseWaiters = (): void => {
+  const waiters = state.closeWaiters;
+  state.closeWaiters = [];
+  for (const w of waiters) {
+    try {
+      w();
+    } catch {
+      // swallow
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Health probe
+// ---------------------------------------------------------------------------
+
+const probeHealthOnce = async (
+  port: number,
+  signal: AbortSignal
+): Promise<boolean> => {
+  // Per Phase 4: explicit AbortController + setTimeout. AbortSignal.timeout()
+  // segfaulted LLRT under ECONNREFUSED, so the start-time poller (which hits
+  // ECONNREFUSED until the child binds) is exactly the kind of call that
+  // must not use it.
+  const inner = new AbortController();
+  const onAbort = () => inner.abort();
+  signal.addEventListener("abort", onAbort);
+  const timer = setTimeout(() => inner.abort(), HEALTH_FETCH_TIMEOUT_MS);
+  try {
+    const r = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: inner.signal,
+    });
+    return r.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+    signal.removeEventListener("abort", onAbort);
+  }
+};
+
+const sleep = (ms: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+// Polls GET /health on the configured port until it answers OK or the
+// 5-second wall clock elapses. Honours an abort signal so the child's close
+// event can short-circuit the wait when spawn fails out from under us.
+const waitForHealthy = async (
+  port: number,
+  signal: AbortSignal
+): Promise<boolean> => {
+  const deadline = Date.now() + HEALTH_POLL_TIMEOUT_MS;
+  while (!signal.aborted && Date.now() < deadline) {
+    if (await probeHealthOnce(port, signal)) return true;
+    await sleep(HEALTH_POLL_INTERVAL_MS, signal);
+  }
+  return false;
+};
+
+// ---------------------------------------------------------------------------
+// Public lifecycle: start / stop / restart
+// ---------------------------------------------------------------------------
+
+const buildSpawnArgs = async (a: StartArgs): Promise<string[]> => {
+  const args = [
+    "--project-name",
+    a.project,
+    "--proxy-port",
+    String(a.port),
+    "--headless",
+  ];
+  // Watchdog: jxscout self-exits if this Caido plugin process dies, so a
+  // managed instance is never left dangling -- even on a hard kill of Caido
+  // that runs no plugin teardown. Keyed to the same pid as our managed-pids
+  // lock files. recoverOrphan() on next launch is the backstop for the gap
+  // between Caido's death and the watchdog's next poll. Omitted when our pid
+  // is unknown (see getOwnPid) -- orphan recovery then carries the load.
+  const ownPid = await getOwnPid();
+  if (ownPid > 0) {
+    args.push("--parent-pid", String(ownPid));
+  }
+  const projectsDir =
+    typeof a.defaultProjectsDir === "string"
+      ? a.defaultProjectsDir.trim()
+      : "";
+  if (projectsDir.length > 0) {
+    args.push("--working-directory", path.join(projectsDir, a.project));
+  }
+  return args;
+};
+
+export type StartResult =
+  | { success: true; pid: number; port: number }
+  | { success: false; error: string };
+
+// jxscout refuses to open a project that's already locked, printing:
+//   Project 'x' is already open in another jxscout instance (PID: 58183)
+// We parse that PID so a leftover orphan from a prior session (whose teardown
+// raced this launch) can be reaped and the start retried.
+const LOCK_CONFLICT_RE =
+  /already open in another jxscout instance \(PID:\s*(\d+)\)/i;
+
+const parseLockConflictPid = (msg: string | null | undefined): number | null => {
+  if (!msg) return null;
+  const m = LOCK_CONFLICT_RE.exec(msg);
+  const raw = m?.[1];
+  if (!raw) return null;
+  const pid = parseInt(raw, 10);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+};
+
+// Poll until `pid` is gone, up to `timeoutMs`. True once it's confirmed dead.
+const waitForPidDeath = async (
+  pid: number,
+  timeoutMs: number
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await isPidAlive(pid))) return true;
+    await new Promise<void>((r) => setTimeout(r, 100));
+  }
+  return !(await isPidAlive(pid));
+};
+
+// Reap a jxscout instance by pid ONLY if it's one we manage -- i.e. its pid
+// appears in one of our managed-pids files AND that file's owner Caido is us or
+// dead. Never touches a foreign/user-run jxscout, nor one owned by a live
+// sibling Caido (same rule as recoverOrphan). Returns:
+//   "reaped"  - was ours, now dead, pid file removed
+//   "alive"   - was ours, survived SIGTERM + SIGKILL
+//   "foreign" - not ours (or owned by a live sibling); left untouched
+const reapManagedJxscout = async (
+  sdk: SDK,
+  jxscoutPid: number
+): Promise<"reaped" | "alive" | "foreign"> => {
+  const dir = managedPidsDirPath(sdk);
+  const self = await getOwnPid();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return "foreign";
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".pid")) continue;
+    let recorded: number | null = null;
+    try {
+      const raw = await readFile(path.join(dir, entry), "utf-8");
+      const n = parseInt(raw.trim(), 10);
+      if (Number.isFinite(n) && n > 0) recorded = n;
+    } catch {
+      continue;
+    }
+    if (recorded !== jxscoutPid) continue;
+
+    // Found the owning pid file. Don't reap a live sibling Caido's instance.
+    const ownerPid = parseInt(entry.slice(0, -".pid".length), 10);
+    if (
+      Number.isFinite(ownerPid) &&
+      ownerPid !== self &&
+      (await isPidAlive(ownerPid))
+    ) {
+      return "foreign";
+    }
+
+    if (await isPidAlive(jxscoutPid)) {
+      sdk.console.log(
+        `supervisor: reaping stale lock-holder jxscout pid=${jxscoutPid} (owner Caido pid=${ownerPid})`
+      );
+      await signalPid(jxscoutPid, "TERM");
+      if (!(await waitForPidDeath(jxscoutPid, ORPHAN_GRACE_MS))) {
+        sdk.console.warn(
+          `supervisor: lock-holder pid=${jxscoutPid} survived SIGTERM, sending SIGKILL`
+        );
+        await signalPid(jxscoutPid, "KILL");
+        if (!(await waitForPidDeath(jxscoutPid, ORPHAN_GRACE_MS))) return "alive";
+      }
+    }
+
+    try {
+      await rm(path.join(dir, entry), { force: true });
+    } catch (err) {
+      sdk.console.error(`supervisor: failed to delete pid file ${entry}: ${err}`);
+    }
+    return "reaped";
+  }
+
+  return "foreign";
+};
+
+// Public entrypoint. Tries to start; if startup fails purely because the
+// project is still locked by a PRIOR jxscout instance we spawned (a leftover
+// orphan whose teardown raced this launch), reap it and retry exactly once. A
+// lock held by a foreign (user-run) jxscout is surfaced as a clear, actionable
+// error instead of the raw "exited with code 1" stderr dump.
+export const startJxscout = async (
+  sdk: SDK,
+  args: StartArgs
+): Promise<StartResult> => {
+  const first = await startJxscoutOnce(sdk, args);
+  if (first.success) return first;
+
+  const lockPid = parseLockConflictPid(first.error);
+  if (lockPid === null) return first;
+
+  const outcome = await reapManagedJxscout(sdk, lockPid);
+  if (outcome === "foreign") {
+    return {
+      success: false,
+      error: `Project '${args.project}' is already open in another jxscout instance (PID: ${lockPid}) that this plugin didn't start. Close it before launching managed mode.`,
+    };
+  }
+  if (outcome === "alive") {
+    return {
+      success: false,
+      error: `Couldn't free the project lock held by a previous jxscout instance (PID: ${lockPid}).`,
+    };
+  }
+
+  sdk.console.log(
+    `supervisor: reaped stale lock-holder pid=${lockPid}, retrying start`
+  );
+  return startJxscoutOnce(sdk, args);
+};
+
+const startJxscoutOnce = async (
+  sdk: SDK,
+  args: StartArgs
+): Promise<StartResult> => {
+  if (state.state === "running" || state.state === "starting") {
+    return {
+      success: false,
+      error: `Supervisor busy: state=${state.state}`,
+    };
+  }
+
+  if (!args || typeof args.binaryPath !== "string") {
+    return { success: false, error: "binaryPath is required" };
+  }
+  if (typeof args.project !== "string" || args.project.trim().length === 0) {
+    return { success: false, error: "project is required" };
+  }
+  if (!Number.isFinite(args.port) || args.port <= 0) {
+    return { success: false, error: `invalid port: ${args.port}` };
+  }
+
+  // Validate the binary before spawning. Phase 5 gotcha: discovery and
+  // validation are separate steps, and a stale customBinaryPath can survive
+  // both. Re-validating here catches "user deleted the binary since last
+  // launch" + "user pointed at a non-jxscout binary".
+  const validation = await validateBinary(args.binaryPath);
+  if (!validation.valid) {
+    transition(sdk, "failed", {
+      pid: null,
+      port: args.port,
+      startedAt: null,
+      lastError: `Binary invalid: ${validation.error ?? "unknown error"}`,
+      manuallyStopped: false,
+    });
+    return {
+      success: false,
+      error: validation.error ?? "Binary validation failed",
+    };
+  }
+
+  const spawnArgs = await buildSpawnArgs(args);
+  sdk.console.log(
+    `supervisor: spawning ${args.binaryPath} ${spawnArgs.join(" ")}`
+  );
+
+  // Clear stale state from a previous failed attempt before re-entering
+  // starting. lastError stays cleared until the next failure.
+  transition(sdk, "starting", {
+    pid: null,
+    port: args.port,
+    startedAt: null,
+    lastError: null,
+    manuallyStopped: false,
+    project: args.project,
+  });
+
+  let child: ChildProcess;
+  try {
+    child = spawn(args.binaryPath, spawnArgs, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    transition(sdk, "failed", {
+      lastError: `Spawn threw: ${String(err)}`,
+    });
+    return { success: false, error: String(err) };
+  }
+
+  if (typeof child.pid !== "number") {
+    transition(sdk, "failed", {
+      lastError: "Spawn returned no pid",
+    });
+    return { success: false, error: "Spawn returned no pid" };
+  }
+
+  state.child = child;
+  // Drain stdout to keep the pipe from filling under backpressure. We don't
+  // surface plain stdout anywhere (Phase 6 removed the logs feature).
+  child.stdout?.on("data", () => {});
+  // Keep the tail of stderr so non-zero exits can report *why* jxscout died
+  // instead of just "code 1". Ring-buffered to ~2KB so a verbose process
+  // that runs for hours doesn't accumulate megabytes of logs.
+  let stderrTail = "";
+  child.stderr?.on("data", (chunk: unknown) => {
+    stderrTail += String(chunk);
+    if (stderrTail.length > STDERR_TAIL_BYTES) {
+      stderrTail = stderrTail.slice(stderrTail.length - STDERR_TAIL_BYTES);
+    }
+  });
+  const formatStderrSuffix = (): string => {
+    const trimmed = stderrTail.trim();
+    if (trimmed.length === 0) return "";
+    return `: ${trimmed.slice(-STDERR_TAIL_BYTES)}`;
+  };
+
+  const healthAbort = new AbortController();
+  state.healthAbort = healthAbort;
+
+  child.on("error", (err: Error) => {
+    sdk.console.error(`supervisor: child error: ${err.message ?? err}`);
+    // 'error' before 'close' typically means spawn failed (e.g. ENOENT).
+    // We still expect 'close' to fire shortly; record the message for the
+    // close handler to consume.
+    if (!state.lastError) {
+      state.lastError = err.message ?? String(err);
+    }
+  });
+
+  child.on("close", async (code: number | null) => {
+    const exitCode = code;
+    sdk.console.log(`supervisor: child closed with code=${exitCode}`);
+    // Stop the health poller if it's still spinning.
+    try {
+      healthAbort.abort();
+    } catch {
+      // swallow
+    }
+
+    const wasManual = state.manuallyStopped;
+    const wasStarting = state.state === "starting";
+    const wasRunning = state.state === "running";
+
+    state.child = null;
+    state.healthAbort = null;
+    await deletePidFile(sdk);
+
+    if (wasManual) {
+      // User-initiated stop; the stop handler already set manuallyStopped.
+      transition(sdk, "stopped", {
+        pid: null,
+        startedAt: null,
+        project: null,
+      });
+    } else if (wasStarting) {
+      // Died during the /health probe -- likely a spawn failure (bad binary
+      // path, port in use, etc.) or an immediate panic.
+      transition(sdk, "failed", {
+        pid: null,
+        startedAt: null,
+        lastError:
+          state.lastError ??
+          `Exited during startup with code ${exitCode ?? "?"}${formatStderrSuffix()}`,
+        project: null,
+      });
+    } else if (wasRunning && exitCode === 0) {
+      // Clean exit while running -- treat as stopped, not failed. (E.g.
+      // user killed the process with SIGTERM externally.)
+      transition(sdk, "stopped", {
+        pid: null,
+        startedAt: null,
+        project: null,
+      });
+    } else if (wasRunning) {
+      transition(sdk, "failed", {
+        pid: null,
+        startedAt: null,
+        lastError: `Exited unexpectedly with code ${exitCode ?? "?"}${formatStderrSuffix()}`,
+        project: null,
+      });
+    }
+
+    resolveCloseWaiters();
+  });
+
+  try {
+    await writePidFile(sdk, child.pid);
+  } catch (err) {
+    sdk.console.error(`supervisor: failed to write pid file: ${err}`);
+    // Not fatal; orphan recovery will still work via the close event for
+    // this session, just not across plugin reloads. Continue.
+  }
+
+  const healthy = await waitForHealthy(args.port, healthAbort.signal);
+  if (!healthy) {
+    // Either the child died (the close handler will run shortly and finish
+    // the failed transition) or /health never responded within 5s. Force
+    // the latter case forward by killing the child; the close handler then
+    // does the state transition.
+    if (state.child === child) {
+      sdk.console.warn(
+        `supervisor: /health did not respond within ${HEALTH_POLL_TIMEOUT_MS}ms; killing child`
+      );
+      state.lastError = `Health probe timed out after ${HEALTH_POLL_TIMEOUT_MS}ms${formatStderrSuffix()}`;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // swallow
+      }
+      // Wait briefly for the close event to settle so the caller gets a
+      // failed snapshot, not the in-progress starting one.
+      await waitForClose(STOP_GRACE_MS);
+    }
+    return {
+      success: false,
+      error: state.lastError ?? "Health probe failed",
+    };
+  }
+
+  if (state.child !== child) {
+    // The child closed during the probe window; the close handler already
+    // settled state into failed/stopped. Return the recorded error.
+    return {
+      success: false,
+      error: state.lastError ?? "Child exited during startup",
+    };
+  }
+
+  transition(sdk, "running", {
+    pid: child.pid,
+    port: args.port,
+    startedAt: Date.now(),
+    lastError: null,
+    manuallyStopped: false,
+  });
+
+  return { success: true, pid: child.pid, port: args.port };
+};
+
+const waitForClose = (timeoutMs: number): Promise<boolean> => {
+  if (!state.child) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (closed: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(closed);
+    };
+    const timer = setTimeout(() => settle(false), timeoutMs);
+    state.closeWaiters.push(() => {
+      clearTimeout(timer);
+      settle(true);
+    });
+  });
+};
+
+export type StopResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export const stopJxscout = async (sdk: SDK): Promise<StopResult> => {
+  if (state.state === "stopped") {
+    // Already stopped; clear lastError so a previous failure doesn't linger
+    // in the UI after the user explicitly stops.
+    if (state.lastError) {
+      state.lastError = null;
+      emitState(sdk, snapshot());
+    }
+    state.manuallyStopped = true;
+    return { success: true };
+  }
+
+  const child = state.child;
+  if (!child) {
+    // State says running/starting/failed but no child object -- treat as a
+    // forced reset to stopped.
+    transition(sdk, "stopped", {
+      pid: null,
+      startedAt: null,
+      manuallyStopped: true,
+      project: null,
+    });
+    return { success: true };
+  }
+
+  state.manuallyStopped = true;
+
+  try {
+    child.kill("SIGTERM");
+  } catch (err) {
+    sdk.console.error(`supervisor: SIGTERM threw: ${err}`);
+  }
+
+  const closed = await waitForClose(STOP_GRACE_MS);
+  if (!closed && state.child) {
+    sdk.console.warn(
+      `supervisor: child did not exit within ${STOP_GRACE_MS}ms, sending SIGKILL`
+    );
+    try {
+      state.child.kill("SIGKILL");
+    } catch (err) {
+      sdk.console.error(`supervisor: SIGKILL threw: ${err}`);
+    }
+    await waitForClose(STOP_GRACE_MS);
+  }
+
+  return { success: true };
+};
+
+export const restartJxscout = async (
+  sdk: SDK,
+  args: StartArgs
+): Promise<StartResult> => {
+  if (state.state !== "stopped") {
+    const stopRes = await stopJxscout(sdk);
+    if (!stopRes.success) {
+      return { success: false, error: stopRes.error };
+    }
+  }
+  // stopJxscout sets manuallyStopped; clear it so a subsequent auto-launch
+  // (Phase 8) treats the restart as an intentional fresh start.
+  state.manuallyStopped = false;
+  return startJxscout(sdk, args);
+};
+
+// ---------------------------------------------------------------------------
+// Orphan recovery (plugin init)
+//
+// We scan ${sdk.meta.path()}/managed-pids/*.pid. Each file is named after a
+// Caido plugin-process pid (the owner) and contains the jxscout pid it
+// supervises. For each:
+//   - owner pid still alive AND not us  -> sibling Caido is running; leave alone
+//   - owner pid is us (stale file from a previous run with the same pid, or
+//     left over after a hard crash) -> treat as orphan, SIGTERM jxscout, delete
+//   - owner pid is dead              -> orphan, SIGTERM jxscout, delete
+//
+// Pid reuse can in theory cause us to leave a stale file in place a bit too
+// long (owner-pid got recycled by some unrelated OS process). That's a
+// cosmetic leak, not a correctness bug -- jxscout's actual pid is checked
+// separately before we signal it.
+// ---------------------------------------------------------------------------
+
+export const recoverOrphan = async (sdk: SDK): Promise<void> => {
+  const dir = managedPidsDirPath(sdk);
+  const self = await getOwnPid();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    // Dir doesn't exist yet -- no recovery needed.
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".pid")) continue;
+    const ownerPid = parseInt(entry.slice(0, -".pid".length), 10);
+    if (!Number.isFinite(ownerPid) || ownerPid <= 0) continue;
+
+    // Owner alive and not us -> sibling Caido is running its own jxscout.
+    // Don't touch it. (Pid reuse: if some unrelated OS process happens to
+    // have grabbed this pid, we'll leak the file until the real owner
+    // exits. Acceptable -- the jxscout pid inside isn't signalled either,
+    // and the file is overwritten next time we hit this pid ourselves.)
+    if (ownerPid !== self && (await isPidAlive(ownerPid))) {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry);
+    let jxscoutPid: number | null = null;
+    try {
+      const raw = await readFile(fullPath, "utf-8");
+      const n = parseInt(raw.trim(), 10);
+      if (Number.isFinite(n) && n > 0) jxscoutPid = n;
+    } catch {
+      // unreadable -- skip the signal step, just delete below
+    }
+
+    if (jxscoutPid !== null && (await isPidAlive(jxscoutPid))) {
+      sdk.console.log(
+        `supervisor: orphan jxscout pid=${jxscoutPid} (owner Caido pid=${ownerPid} ${
+          ownerPid === self ? "is us, file is stale" : "is dead"
+        }), SIGTERM`
+      );
+      await signalPid(jxscoutPid, "TERM");
+
+      const deadline = Date.now() + ORPHAN_GRACE_MS;
+      while (Date.now() < deadline) {
+        if (!(await isPidAlive(jxscoutPid))) break;
+        await new Promise<void>((r) => setTimeout(r, 200));
+      }
+      if (await isPidAlive(jxscoutPid)) {
+        sdk.console.warn(
+          `supervisor: orphan pid=${jxscoutPid} survived SIGTERM, sending SIGKILL`
+        );
+        await signalPid(jxscoutPid, "KILL");
+      }
+    }
+
+    try {
+      await rm(fullPath, { force: true });
+    } catch (err) {
+      sdk.console.error(
+        `supervisor: failed to delete stale pid file ${fullPath}: ${err}`
+      );
+    }
+  }
+};

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -1,7 +1,36 @@
+export type Mode = "manual" | "managed";
+
 export type Settings = {
-    port: number;
+    // Manual-mode connection target. The plugin POSTs/GETs to
+    // http://{host}:{port}/... when the user runs jxscout themselves.
+    // Managed mode ignores both: it binds 127.0.0.1 and auto-allocates the
+    // port at every supervisor start.
     host: string;
+    port: number;
     filterInScope: boolean;
+    mode: Mode;
+    customBinaryPath: string | null;
+    defaultProjectsDir: string | null;
+    autoLaunch: boolean;
+    autoSync: boolean;
+}
+
+export type ProjectEntry = {
+    name: string;
+    path: string;
+}
+
+export type StoredLicense = {
+    license_key: string;
+    machine_fingerprint: string | null;
+}
+
+// Mirrors HealthResponse in crates/core/proxy-api/src/handlers.rs.
+export type JxscoutStatus = {
+    status: string;
+    project: string;
+    working_directory: string;
+    version: string;
 }
 
 export type Response<T> = {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,15 +6,15 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "@caido/primevue": "0.1.2",
+    "@caido/primevue": "0.3.3",
     "primevue": "4.1.0",
-    "vue": "3.4.37"
+    "vue": "3.5.34"
   },
   "devDependencies": {
-    "@caido/sdk-backend": "^0.51.1",
-    "@caido/sdk-frontend": "^0.51.1",
-    "@codemirror/view": "6.28.1",
+    "@caido/sdk-backend": "0.56.0",
+    "@caido/sdk-frontend": "0.56.0",
+    "@codemirror/view": "6.42.1",
     "backend": "workspace:*",
-    "vue-tsc": "2.0.29"
+    "vue-tsc": "3.2.8"
   }
 }

--- a/packages/frontend/src/components/AutoSyncPill.vue
+++ b/packages/frontend/src/components/AutoSyncPill.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { useAutoSync } from "@/composables/useAutoSync";
+
+// Phase 8: transient pill rendered above the Managed status card while an
+// auto-sync action is in flight. Visible for ~1.5s after each `auto-sync`
+// event the backend emits (`useAutoSync` owns the lifetime). Rendered in both
+// ManagedRunning and ManagedIdle so it stays on screen across the supervisor
+// stopped -> starting -> running cycle during a project switch.
+const { event } = useAutoSync();
+
+const label = computed(() => {
+  const e = event.value;
+  if (!e) return "";
+  if (e.kind === "switching") return `Switching project → ${e.to}…`;
+  return "Stopping jxscout — Caido project closed…";
+});
+</script>
+
+<template>
+  <div
+    v-if="event !== null"
+    class="flex items-center gap-2 rounded-md border border-surface-600 bg-surface-800 px-3 py-2 text-xs text-surface-700 dark:text-surface-200 ring-1 ring-secondary-500/30"
+    role="status"
+    aria-live="polite"
+  >
+    <span
+      class="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-secondary-400"
+      aria-hidden="true"
+    ></span>
+    <span>{{ label }}</span>
+  </div>
+</template>

--- a/packages/frontend/src/components/BinarySetup.vue
+++ b/packages/frontend/src/components/BinarySetup.vue
@@ -1,0 +1,471 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import InputText from "primevue/inputtext";
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import type { DownloadProgress } from "backend";
+
+import { useBinary } from "@/composables/useBinary";
+import { useSettings } from "@/composables/useSettings";
+import { useSupervisor } from "@/composables/useSupervisor";
+import { useSDK } from "@/plugins/sdk";
+
+const props = defineProps<{
+  // Allows reopening BIN-3 inline from <ManagedSettings />. Default is BIN-1
+  // (the plan's confirmed UX: sub-state is component-local; remount resets
+  // to BIN-1).
+  initialView?: "choice" | "specify";
+}>();
+
+const emit = defineEmits<{
+  (e: "back"): void;
+}>();
+
+type View = "choice" | "downloading" | "specify";
+
+const view = ref<View>(props.initialView === "specify" ? "specify" : "choice");
+
+const sdk = useSDK();
+const binary = useBinary();
+const settingsState = useSettings();
+const supervisor = useSupervisor();
+
+// After a successful download or path save, kick off the supervisor when
+// auto-launch is on. Mirrors plugin-init auto-launch but for the "user just
+// finished setup" moment — without it the user is dumped on a Stopped card
+// and has to click Start, which is friction when they already opted into
+// auto-launch.
+const maybeAutoStart = async () => {
+  if (!settingsState.settings.value.autoLaunch) return;
+  const result = await supervisor.start();
+  if (!result.success) {
+    sdk.window.showToast(`Failed to auto-start: ${result.error}`, {
+      variant: "error",
+    });
+  }
+};
+
+// BIN-3 state ---------------------------------------------------------------
+// Absolute path typed/pasted by the user. A native file picker would be
+// nicer, but Electron 32+ stripped File.path and Caido's plugin SDK doesn't
+// expose webUtils.getPathForFile — so renderer-side picking can't recover
+// an absolute path. The backend validates the string via `--version`.
+const specifyPath = ref("");
+const isValidating = ref(false);
+const validationError = ref<string | null>(null);
+
+const canValidate = computed(
+  () => specifyPath.value.trim().length > 0 && !isValidating.value
+);
+
+const onSpecify = () => {
+  view.value = "specify";
+};
+
+const onValidateAndSave = async () => {
+  if (!canValidate.value) return;
+  isValidating.value = true;
+  validationError.value = null;
+  try {
+    const trimmed = specifyPath.value.trim();
+    const validation = await sdk.backend.validateBinary(trimmed);
+    if (!validation.valid) {
+      validationError.value = validation.error ?? "Validation failed";
+      return;
+    }
+    const saved = await sdk.backend.setCustomBinaryPath(trimmed);
+    if (!saved.success) {
+      validationError.value = saved.error;
+      return;
+    }
+    sdk.window.showToast(`Binary set to ${trimmed}`, { variant: "success" });
+    specifyPath.value = "";
+    await Promise.all([settingsState.load(), binary.refresh()]);
+    await maybeAutoStart();
+  } catch (err) {
+    validationError.value = String(err);
+  } finally {
+    isValidating.value = false;
+  }
+};
+
+// BIN-2 state ---------------------------------------------------------------
+const progress = ref<DownloadProgress | null>(null);
+const isDownloading = ref(false);
+let unsubscribe: { stop: () => void } | null = null;
+
+// Attach the progress listener as soon as the card mounts. It's cheap and
+// keeps timing simple: events emitted during the resolver-resolve hop
+// don't race the subscribe call.
+onMounted(() => {
+  unsubscribe = sdk.backend.onEvent("download-progress", (next) => {
+    progress.value = next;
+  });
+});
+
+onUnmounted(() => {
+  if (unsubscribe) {
+    try {
+      unsubscribe.stop();
+    } catch {
+      // swallow
+    }
+  }
+});
+
+const onDownload = async () => {
+  view.value = "downloading";
+  isDownloading.value = true;
+  progress.value = { kind: "resolving" };
+  try {
+    const result = await sdk.backend.downloadBinary();
+    if (result.success) {
+      sdk.window.showToast(`Binary installed at ${result.path}`, {
+        variant: "success",
+      });
+      await binary.refresh();
+      // No need to flip the view back; <ManagedView /> will route past
+      // <BinarySetup /> once detection reflects the install.
+      await maybeAutoStart();
+    } else {
+      // Stay on the downloading view so the user can read the error from
+      // the rendered progress card; offer a "Try again / Specify path"
+      // affordance.
+      sdk.window.showToast(`Download failed: ${result.error}`, {
+        variant: "error",
+      });
+    }
+  } catch (err) {
+    sdk.window.showToast(`Download failed: ${err}`, { variant: "error" });
+  } finally {
+    isDownloading.value = false;
+  }
+};
+
+const onRetryDownload = () => {
+  progress.value = null;
+  void onDownload();
+};
+
+const platformLabel = computed(() => {
+  const rt = binary.releaseType.value;
+  if (!binary.releaseTypeLoaded.value) return "detecting platform…";
+  if (rt === null) return "Unsupported platform";
+  // Pretty labels matching the marketing site.
+  switch (rt) {
+    case "linux-386":
+      return "Linux (x86 32-bit)";
+    case "linux-amd64":
+      return "Linux (x86_64)";
+    case "linux-arm64":
+      return "Linux (ARM64)";
+    case "macos-amd64":
+      return "macOS (Intel)";
+    case "macos-arm64":
+      return "macOS (Apple Silicon)";
+    case "windows-amd64":
+      return "Windows (x86_64)";
+    case "windows-arm64":
+      return "Windows (ARM64)";
+  }
+});
+
+const isMacOS = computed(() => {
+  const rt = binary.releaseType.value;
+  return rt === "macos-amd64" || rt === "macos-arm64";
+});
+
+const isLinux = computed(() => {
+  const rt = binary.releaseType.value;
+  return (
+    rt === "linux-386" || rt === "linux-amd64" || rt === "linux-arm64"
+  );
+});
+
+const isWindows = computed(() => {
+  const rt = binary.releaseType.value;
+  return rt === "windows-amd64" || rt === "windows-arm64";
+});
+
+const progressLabel = computed(() => {
+  const p = progress.value;
+  if (!p) return "";
+  switch (p.kind) {
+    case "resolving":
+      return "Resolving download URL…";
+    case "downloading":
+      if (p.total === null || p.total === 0) {
+        return `Downloading… (${formatBytes(p.bytes)})`;
+      }
+      return `Downloading… (${formatBytes(p.bytes)} of ${formatBytes(p.total)})`;
+    case "extracting":
+      return "Extracting archive…";
+    case "installing":
+      return "Installing binary…";
+    case "done":
+      return `Installed v${p.version}`;
+    case "error":
+      return `Failed: ${p.error}`;
+  }
+});
+
+const progressFraction = computed(() => {
+  const p = progress.value;
+  if (!p) return 0;
+  if (p.kind === "resolving") return 0.05;
+  if (p.kind === "downloading") {
+    if (p.total === null || p.total === 0) return 0.5;
+    return Math.min(0.85, 0.1 + (p.bytes / p.total) * 0.75);
+  }
+  if (p.kind === "extracting") return 0.9;
+  if (p.kind === "installing") return 0.95;
+  if (p.kind === "done") return 1;
+  return 0;
+});
+
+const formatBytes = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+};
+
+const onBack = () => {
+  if (props.initialView) {
+    emit("back");
+    return;
+  }
+  view.value = "choice";
+};
+</script>
+
+<template>
+  <!-- BIN-1: choice -->
+  <div
+    v-if="view === 'choice'"
+    class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-4"
+  >
+    <div>
+      <h3
+        class="m-0 text-sm font-semibold text-surface-800 dark:text-white/80"
+      >
+        Set up jxscout-pro-v2
+      </h3>
+      <p
+        class="m-0 mt-1 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Caido couldn't find the <code class="font-mono">jxscout-pro-v2</code>
+        binary on this machine. Either download it from
+        <a
+          href="https://jxscout.app/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-info-400 hover:underline"
+          >jxscout.app</a
+        >
+        or point to an existing copy.
+      </p>
+    </div>
+
+    <button
+      type="button"
+      :disabled="binary.releaseType.value === null"
+      class="flex flex-col items-start gap-1 rounded-md border border-surface-600 bg-surface-700 p-3 text-left transition hover:border-secondary-500/40 hover:ring-1 hover:ring-secondary-500/30 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-surface-600 disabled:hover:ring-0"
+      @click="onDownload"
+    >
+      <div class="flex w-full items-center justify-between gap-2">
+        <span
+          class="text-sm font-semibold text-surface-800 dark:text-white/80"
+          >Download for {{ platformLabel }}</span
+        >
+        <span
+          class="rounded-full bg-secondary-500/15 px-2 py-0.5 text-xs font-medium text-secondary-300"
+          >Recommended</span
+        >
+      </div>
+      <span
+        class="text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Fetches the latest release from jxscout.app using your license key,
+        installs it at <code class="font-mono">~/.jxscout-pro/bin/</code>, and
+        starts it.
+      </span>
+      <span
+        v-if="binary.releaseType.value === null"
+        class="text-xs text-red-400"
+      >
+        This platform doesn't have a prebuilt release. Pick "Specify path"
+        and select a self-built binary.
+      </span>
+    </button>
+
+    <button
+      type="button"
+      class="flex flex-col items-start gap-1 rounded-md border border-surface-600 bg-surface-700 p-3 text-left transition hover:border-surface-500"
+      @click="onSpecify"
+    >
+      <span class="text-sm font-semibold text-surface-800 dark:text-white/80"
+        >Specify path</span
+      >
+      <span
+        class="text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Already have <code class="font-mono">jxscout-pro-v2</code> installed?
+        Select the binary file.
+      </span>
+    </button>
+
+    <div class="flex items-center justify-between pt-1">
+      <Button
+        label="Back to Manual"
+        severity="secondary"
+        text
+        @click="settingsState.save({ mode: 'manual' })"
+      />
+    </div>
+  </div>
+
+  <!-- BIN-2: download progress -->
+  <div
+    v-else-if="view === 'downloading'"
+    class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-4"
+    :class="{
+      'ring-1 ring-success-500/30': progress?.kind === 'done',
+      'ring-1 ring-red-500/30': progress?.kind === 'error',
+    }"
+  >
+    <div>
+      <h3
+        class="m-0 text-sm font-semibold text-surface-800 dark:text-white/80"
+      >
+        Installing jxscout-pro-v2
+      </h3>
+      <p
+        class="m-0 mt-1 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        {{ progressLabel }}
+      </p>
+    </div>
+
+    <div
+      v-if="progress?.kind !== 'error'"
+      class="h-2 w-full overflow-hidden rounded-full bg-surface-700"
+      aria-hidden="true"
+    >
+      <div
+        class="h-full bg-secondary-500 transition-all"
+        :style="{ width: `${progressFraction * 100}%` }"
+      ></div>
+    </div>
+
+    <p
+      v-if="progress?.kind === 'error'"
+      class="m-0 break-words rounded-md border border-red-500/30 bg-red-500/10 p-2 text-sm text-red-300"
+    >
+      {{ progress.error }}
+    </p>
+
+    <!-- Post-install OS guidance: macOS Gatekeeper + Linux execute bit -->
+    <p
+      v-if="progress?.kind === 'done' && isMacOS"
+      class="m-0 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+    >
+      <strong class="text-surface-700 dark:text-surface-200">macOS:</strong>
+      The binary isn't notarized. If Gatekeeper blocks the first launch, open
+      <strong>System Settings &gt; Privacy &amp; Security</strong> and click
+      <em>Allow Anyway</em> next to the jxscout-pro-v2 entry, then retry
+      Start.
+    </p>
+    <p
+      v-if="progress?.kind === 'done' && isWindows"
+      class="m-0 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+    >
+      <strong class="text-surface-700 dark:text-surface-200">Windows:</strong>
+      The binary isn't signed. If SmartScreen blocks it, click
+      <em>More info &rarr; Run anyway</em>.
+    </p>
+    <p
+      v-if="progress?.kind === 'done' && isLinux"
+      class="m-0 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+    >
+      Installed at <code class="font-mono">~/.jxscout-pro/bin/jxscout-pro-v2</code>.
+    </p>
+
+    <div class="flex items-center justify-between pt-1">
+      <Button
+        v-if="!isDownloading"
+        label="Back"
+        severity="secondary"
+        text
+        @click="onBack"
+      />
+      <span v-else></span>
+
+      <Button
+        v-if="progress?.kind === 'error'"
+        label="Try again"
+        severity="warn"
+        @click="onRetryDownload"
+      />
+    </div>
+  </div>
+
+  <!-- BIN-3: specify path -->
+  <div
+    v-else
+    class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-4"
+  >
+    <div>
+      <h3
+        class="m-0 text-sm font-semibold text-surface-800 dark:text-white/80"
+      >
+        Select binary
+      </h3>
+      <p
+        class="m-0 mt-1 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Paste the absolute path to <code class="font-mono">jxscout-pro-v2</code>.
+        Tip: drag the binary onto a terminal window to reveal its path, or run
+        <code class="font-mono">which jxscout-pro-v2</code>. The path is
+        validated with <code class="font-mono">--version</code> before saving.
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <InputText
+        v-model="specifyPath"
+        placeholder="/path/to/jxscout-pro-v2"
+        spellcheck="false"
+        autocapitalize="off"
+        autocorrect="off"
+        class="font-mono text-xs"
+        :disabled="isValidating"
+        fluid
+        @keydown.enter="onValidateAndSave"
+      />
+      <Button
+        :label="isValidating ? 'Validating…' : 'Validate & Save'"
+        :disabled="!canValidate"
+        :loading="isValidating"
+        @click="onValidateAndSave"
+      />
+    </div>
+
+    <p
+      v-if="validationError"
+      class="m-0 break-words rounded-md border border-red-500/30 bg-red-500/10 p-2 text-sm text-red-300"
+    >
+      {{ validationError }}
+    </p>
+
+    <div class="flex items-center justify-between pt-1">
+      <Button
+        :label="props.initialView ? 'Cancel' : 'Back'"
+        severity="secondary"
+        text
+        :disabled="isValidating"
+        @click="onBack"
+      />
+    </div>
+  </div>
+</template>

--- a/packages/frontend/src/components/ConfirmModeSwitchDialog.vue
+++ b/packages/frontend/src/components/ConfirmModeSwitchDialog.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import { nextTick, ref, watch } from "vue";
+
+defineProps<{
+  open: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "choice", value: "stop" | "keep" | "cancel"): void;
+}>();
+
+const stopButtonRef = ref<InstanceType<typeof Button> | null>(null);
+
+// Plan: default focus on Stop. Wait a tick after the v-if mount so the
+// button's DOM element exists, then call $el.focus(). PrimeVue's <Button>
+// wraps a real <button> at $el.
+watch(
+  () => stopButtonRef.value,
+  async (btn) => {
+    if (!btn) return;
+    await nextTick();
+    const el = (btn as unknown as { $el?: HTMLElement }).$el;
+    if (el && typeof el.focus === "function") el.focus();
+  }
+);
+
+const onKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    emit("choice", "cancel");
+  }
+};
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+    role="presentation"
+    @click.self="emit('choice', 'cancel')"
+    @keydown="onKeydown"
+  >
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-mode-switch-title"
+      class="w-full max-w-sm rounded-md border border-surface-600 bg-surface-800 p-4 shadow-xl"
+    >
+      <h4
+        id="confirm-mode-switch-title"
+        class="m-0 mb-2 text-base font-semibold text-surface-800 dark:text-white/90"
+      >
+        Stop the managed jxscout?
+      </h4>
+      <p class="m-0 mb-4 text-sm text-surface-500 dark:text-surface-400">
+        Switching to Manual mode while jxscout is running. Stop it now, or
+        leave it running and connect to it like a regular Manual jxscout?
+      </p>
+      <div class="flex justify-end gap-2">
+        <Button
+          severity="secondary"
+          text
+          size="small"
+          label="Cancel"
+          @click="emit('choice', 'cancel')"
+        />
+        <Button
+          severity="secondary"
+          size="small"
+          label="Keep running"
+          @click="emit('choice', 'keep')"
+        />
+        <Button
+          ref="stopButtonRef"
+          severity="danger"
+          size="small"
+          label="Stop"
+          @click="emit('choice', 'stop')"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/frontend/src/components/LicenseEntry.vue
+++ b/packages/frontend/src/components/LicenseEntry.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import InputText from "primevue/inputtext";
+import { computed, ref } from "vue";
+
+import { useLicense } from "@/composables/useLicense";
+import { useSettings } from "@/composables/useSettings";
+import { useSDK } from "@/plugins/sdk";
+
+const sdk = useSDK();
+const license = useLicense();
+const settingsState = useSettings();
+
+const key = ref("");
+const isSaving = ref(false);
+
+const canSave = computed(() => key.value.trim().length > 0 && !isSaving.value);
+
+const onBack = async () => {
+  await settingsState.save({ mode: "manual" });
+};
+
+const onSave = async () => {
+  if (!canSave.value) return;
+  isSaving.value = true;
+  try {
+    const response = await sdk.backend.setLicense(key.value.trim());
+    if (response.success) {
+      key.value = "";
+      sdk.window.showToast("License saved", { variant: "success" });
+      await license.refresh();
+    } else {
+      sdk.window.showToast(`Failed to save license: ${response.error}`, {
+        variant: "error",
+      });
+    }
+  } catch (err) {
+    sdk.window.showToast(`Failed to save license: ${err}`, {
+      variant: "error",
+    });
+  } finally {
+    isSaving.value = false;
+  }
+};
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-4"
+  >
+    <div>
+      <h3
+        class="m-0 text-sm font-semibold text-surface-800 dark:text-white/80"
+      >
+        Activate JXScout Pro
+      </h3>
+      <p
+        class="m-0 mt-1 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Paste your license key below. The key is stored at
+        <code class="font-mono">~/.jxscout-pro/.license</code>.
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <label
+        for="jxscout-license-key"
+        class="text-sm font-medium text-surface-700 dark:text-surface-200"
+        >License key</label
+      >
+      <InputText
+        id="jxscout-license-key"
+        v-model="key"
+        class="box-border font-mono"
+        placeholder="Paste here…"
+        :disabled="isSaving"
+        fluid
+        @keydown.enter="onSave"
+      />
+    </div>
+
+    <p class="m-0 text-sm text-surface-500 dark:text-surface-400 leading-snug">
+      Don't have one? Get a license at
+      <a
+        href="https://jxscout.app/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-info-400 hover:underline"
+        >jxscout.app</a
+      >.
+    </p>
+
+    <div class="flex items-center justify-between pt-1">
+      <Button
+        label="Back to Manual"
+        severity="secondary"
+        text
+        :disabled="isSaving || settingsState.isLoading.value"
+        @click="onBack"
+      />
+      <Button
+        label="Save license"
+        severity="warn"
+        :disabled="!canSave"
+        :loading="isSaving"
+        @click="onSave"
+      />
+    </div>
+  </div>
+</template>

--- a/packages/frontend/src/components/ManagedIdle.vue
+++ b/packages/frontend/src/components/ManagedIdle.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import { computed } from "vue";
+
+import AutoSyncPill from "@/components/AutoSyncPill.vue";
+import ManagedSettings from "@/components/ManagedSettings.vue";
+import ScopeSettings from "@/components/ScopeSettings.vue";
+import { useSupervisor } from "@/composables/useSupervisor";
+import { useSDK } from "@/plugins/sdk";
+
+const sdk = useSDK();
+const { snapshot, isBusy, start } = useSupervisor();
+
+const state = computed(() => snapshot.value?.state ?? "stopped");
+
+const onStart = async () => {
+  const r = await start();
+  if (!r.success) {
+    sdk.window.showToast(`Failed to start: ${r.error}`, { variant: "error" });
+  }
+};
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <AutoSyncPill />
+
+    <!-- Starting -->
+    <div
+      v-if="state === 'starting'"
+      class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-3"
+    >
+      <div class="flex items-center gap-2">
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-secondary-500/15 px-2 py-0.5 text-xs font-medium text-secondary-300"
+        >
+          <span
+            class="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-secondary-400"
+            aria-hidden="true"
+          ></span>
+          Starting…
+        </span>
+        <span class="text-xs text-surface-500 dark:text-surface-400">
+          waiting for /health
+        </span>
+      </div>
+    </div>
+
+    <!-- Failed -->
+    <div
+      v-else-if="state === 'failed'"
+      class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-3 ring-1 ring-red-500/30"
+    >
+      <div class="flex items-center justify-between gap-2">
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-medium text-red-300"
+        >
+          <span
+            class="inline-block h-1.5 w-1.5 rounded-full bg-red-500"
+            aria-hidden="true"
+          ></span>
+          Failed
+        </span>
+      </div>
+      <p
+        v-if="snapshot?.lastError"
+        class="m-0 break-words text-sm text-surface-700 dark:text-surface-200"
+      >
+        {{ snapshot.lastError }}
+      </p>
+      <div class="flex justify-end">
+        <Button label="Retry" :loading="isBusy" @click="onStart" />
+      </div>
+    </div>
+
+    <!-- Stopped (default / initial) -->
+    <div
+      v-else
+      class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-3"
+    >
+      <div class="flex items-center gap-2">
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-surface-700 px-2 py-0.5 text-xs font-medium text-surface-300"
+        >
+          <span
+            class="inline-block h-1.5 w-1.5 rounded-full bg-surface-400"
+            aria-hidden="true"
+          ></span>
+          Stopped
+        </span>
+      </div>
+      <p class="m-0 text-sm text-surface-500 dark:text-surface-400">
+        Spawn a managed <code>jxscout-pro-v2</code> on a free local port for
+        the current Caido project.
+      </p>
+      <div class="flex justify-end">
+        <Button label="Start" :loading="isBusy" @click="onStart" />
+      </div>
+    </div>
+
+    <ScopeSettings />
+
+    <ManagedSettings />
+  </div>
+</template>

--- a/packages/frontend/src/components/ManagedRunning.vue
+++ b/packages/frontend/src/components/ManagedRunning.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import { computed } from "vue";
+
+import AutoSyncPill from "@/components/AutoSyncPill.vue";
+import ManagedSettings from "@/components/ManagedSettings.vue";
+import ProjectPicker from "@/components/ProjectPicker.vue";
+import ScopeSettings from "@/components/ScopeSettings.vue";
+import { useBinary } from "@/composables/useBinary";
+import { useJxscoutStatus } from "@/composables/useJxscoutStatus";
+import { useManualProject } from "@/composables/useManualProject";
+import { useSettings } from "@/composables/useSettings";
+import { useSupervisor } from "@/composables/useSupervisor";
+import { useSDK } from "@/plugins/sdk";
+
+const sdk = useSDK();
+const { snapshot, uptimeMs, isBusy, stop, restart } = useSupervisor();
+const { status } = useJxscoutStatus();
+const { settings } = useSettings();
+const manualProject = useManualProject();
+const binary = useBinary();
+
+// Phase 10: Auto-sync OFF -> show the picker; ON -> static text. Plan default
+// keeps the picker out of the user's way when auto-sync is doing the work.
+const autoSyncOff = computed(() => settings.value.autoSync === false);
+const hasManualOverride = computed(
+  () =>
+    typeof manualProject.manualProjectName.value === "string" &&
+    manualProject.manualProjectName.value.trim().length > 0
+);
+
+// Status data comes from the same /health poll that Manual mode uses. In
+// Managed mode the supervisor binds 127.0.0.1:<port>; settings.host defaults
+// to "localhost" + settings.port is persisted to the chosen port, so the
+// poller resolves to the right place without any Managed-specific plumbing.
+// Until /health responds (the ~400ms gap between supervisor 'running' and
+// the first successful poll) status is null and meta rows show "—".
+
+const uptimeLabel = computed(() => {
+  const ms = uptimeMs.value;
+  if (ms === null) return "—";
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+});
+
+const versionLabel = computed(() =>
+  status.value?.version ? `v${status.value.version}` : null
+);
+
+const onStop = async () => {
+  const r = await stop();
+  if (!r.success) {
+    sdk.window.showToast(`Failed to stop: ${r.error}`, { variant: "error" });
+  }
+};
+
+const onRestart = async () => {
+  const r = await restart();
+  if (!r.success) {
+    sdk.window.showToast(`Failed to restart: ${r.error}`, {
+      variant: "error",
+    });
+  }
+};
+
+// "Open in <tool>" buttons under the working-dir row. Each routes through the
+// backend openPath RPC, which spawns the platform-native launcher (open /
+// explorer / xdg-open) or the editor's `code`/`cursor` CLI helper. Surfacing
+// the launch error as a toast helps users diagnose missing CLI installs.
+const onOpenWorkingDir = async (tool: "folder" | "vscode" | "cursor") => {
+  const dir = status.value?.working_directory;
+  if (!dir) return;
+  const result = await sdk.backend.openPath({ path: dir, tool });
+  if (!result.success) {
+    sdk.window.showToast(result.error, { variant: "error" });
+  }
+};
+</script>
+
+<template>
+  <div class="flex min-w-0 flex-col gap-3">
+    <AutoSyncPill />
+
+    <div
+      class="flex min-w-0 flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-3 ring-1 ring-success-500/30"
+    >
+      <div class="flex items-center justify-between gap-2">
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-success-500/15 px-2 py-0.5 text-xs font-medium text-success-300"
+        >
+          <span
+            class="inline-block h-1.5 w-1.5 rounded-full bg-success-500"
+            aria-hidden="true"
+          ></span>
+          Running
+        </span>
+        <span class="text-xs text-surface-500 dark:text-surface-400">
+          uptime {{ uptimeLabel }}<template v-if="versionLabel">
+            · {{ versionLabel }}</template>
+        </span>
+      </div>
+
+      <!-- Meta grid mirrors the C2 / C3 prototype: Project / Working dir /
+           Binary path. Long paths use [overflow-wrap:anywhere] so they break
+           inside the right-hand column without expanding the grid.
+           Placeholder dashes are rendered in the default font (not <code>)
+           so they line up visually with the Project row's dash; the <code>
+           element is only used when there's an actual path to display. -->
+      <div class="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-sm">
+        <span class="text-surface-500 dark:text-surface-400">Project:</span>
+        <ProjectPicker
+          v-if="autoSyncOff"
+          :current-name="status?.project ?? null"
+          :has-manual-override="hasManualOverride"
+        />
+        <span
+          v-else
+          class="min-w-0 break-all text-surface-700 dark:text-surface-200"
+        >
+          {{ status?.project ?? "—" }}
+        </span>
+        <span class="text-surface-500 dark:text-surface-400">Working dir:</span>
+        <div v-if="status?.working_directory" class="min-w-0 flex flex-col gap-1">
+          <code
+            class="block min-w-0 break-all font-mono text-xs text-surface-700 dark:text-surface-200 [overflow-wrap:anywhere]"
+            >{{ status.working_directory }}</code
+          >
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+            <button
+              type="button"
+              class="text-info-400 hover:underline"
+              @click="onOpenWorkingDir('folder')"
+            >
+              Open folder
+            </button>
+            <span class="text-surface-500 dark:text-surface-400" aria-hidden="true">·</span>
+            <button
+              type="button"
+              class="text-info-400 hover:underline"
+              @click="onOpenWorkingDir('vscode')"
+            >
+              VS Code
+            </button>
+            <span class="text-surface-500 dark:text-surface-400" aria-hidden="true">·</span>
+            <button
+              type="button"
+              class="text-info-400 hover:underline"
+              @click="onOpenWorkingDir('cursor')"
+            >
+              Cursor
+            </button>
+          </div>
+        </div>
+        <span
+          v-else
+          class="text-surface-700 dark:text-surface-200"
+          >—</span
+        >
+        <span class="text-surface-500 dark:text-surface-400">Binary:</span>
+        <code
+          v-if="binary.detection.value?.path"
+          class="block min-w-0 break-all font-mono text-xs text-surface-700 dark:text-surface-200 [overflow-wrap:anywhere]"
+          >{{ binary.detection.value.path }}</code
+        >
+        <span
+          v-else
+          class="text-surface-700 dark:text-surface-200"
+          >—</span
+        >
+        <span class="text-surface-500 dark:text-surface-400">PID / port:</span>
+        <span class="font-mono text-surface-700 dark:text-surface-200">
+          {{ snapshot?.pid ?? "—" }} · {{ snapshot?.port ?? "—" }}
+        </span>
+      </div>
+
+      <div class="flex justify-end gap-2">
+        <Button
+          label="Restart"
+          severity="secondary"
+          text
+          size="small"
+          :loading="isBusy"
+          @click="onRestart"
+        />
+        <Button
+          label="Stop"
+          severity="secondary"
+          size="small"
+          :loading="isBusy"
+          @click="onStop"
+        />
+      </div>
+    </div>
+
+    <ScopeSettings />
+
+    <ManagedSettings />
+  </div>
+</template>

--- a/packages/frontend/src/components/ManagedSettings.vue
+++ b/packages/frontend/src/components/ManagedSettings.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import InputText from "primevue/inputtext";
+import ToggleSwitch from "primevue/toggleswitch";
+import { computed, ref, watch } from "vue";
+
+import BinarySetup from "@/components/BinarySetup.vue";
+import { useBinary } from "@/composables/useBinary";
+import { useSettings } from "@/composables/useSettings";
+import { useSDK } from "@/plugins/sdk";
+
+const sdk = useSDK();
+const settingsState = useSettings();
+const binary = useBinary();
+
+const isOpen = ref(false);
+const showBinaryEdit = ref(false);
+const dirInput = ref(settingsState.settings.value.defaultProjectsDir ?? "");
+const isSaving = ref(false);
+
+// Phase 8 toggles. v-model'd onto reactive settings; the @update handlers fire
+// the save RPC + handle the "off -> on" intent reset for autoLaunch.
+const autoLaunchOn = computed(() => settingsState.settings.value.autoLaunch);
+const autoSyncOn = computed(() => settingsState.settings.value.autoSync);
+
+const onAutoLaunchToggle = async (next: boolean) => {
+  await settingsState.save({ autoLaunch: next });
+};
+
+const onAutoSyncToggle = async (next: boolean) => {
+  await settingsState.save({ autoSync: next });
+};
+
+// Keep the input synced with on-disk state when settings reload (e.g. after
+// an out-of-band save). Won't fight user input -- the watcher only fires
+// when the underlying ref changes.
+watch(
+  () => settingsState.settings.value.defaultProjectsDir,
+  (next) => {
+    dirInput.value = next ?? "";
+  }
+);
+
+const onSaveProjectsDir = async () => {
+  isSaving.value = true;
+  try {
+    const trimmed = dirInput.value.trim();
+    const ok = await settingsState.save({
+      defaultProjectsDir: trimmed.length === 0 ? null : trimmed,
+    });
+    if (ok) {
+      sdk.window.showToast("Default projects directory saved", {
+        variant: "success",
+      });
+    }
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const onChangeBinary = () => {
+  showBinaryEdit.value = true;
+};
+
+const onBinaryEditBack = () => {
+  showBinaryEdit.value = false;
+};
+
+const onClearCustomPath = async () => {
+  const response = await sdk.backend.clearCustomBinaryPath();
+  if (response.success) {
+    sdk.window.showToast("Custom binary path cleared", {
+      variant: "success",
+    });
+    await Promise.all([settingsState.load(), binary.refresh()]);
+  } else {
+    sdk.window.showToast(`Failed: ${response.error}`, { variant: "error" });
+  }
+};
+</script>
+
+<template>
+  <details
+    class="rounded-md border border-surface-600 bg-surface-800"
+    :open="isOpen"
+    @toggle="
+      isOpen = ($event.target as HTMLDetailsElement).open;
+      if (isOpen) void binary.refresh();
+    "
+  >
+    <summary
+      class="cursor-pointer select-none px-3 py-2 text-sm font-medium text-surface-700 dark:text-surface-200"
+    >
+      Advanced settings
+    </summary>
+
+    <div
+      v-if="!showBinaryEdit"
+      class="flex min-w-0 flex-col gap-4 border-t border-surface-700 px-3 py-3"
+    >
+      <div class="flex min-w-0 flex-col gap-1">
+        <label
+          for="jxscout-default-projects-dir"
+          class="text-sm font-medium text-surface-700 dark:text-surface-200"
+          >Default projects directory</label
+        >
+        <InputText
+          id="jxscout-default-projects-dir"
+          v-model="dirInput"
+          class="box-border font-mono"
+          placeholder="~/jxscout-pro (default)"
+          :disabled="isSaving"
+          fluid
+        />
+        <div class="flex justify-end pt-1">
+          <Button
+            label="Save"
+            severity="secondary"
+            size="small"
+            :loading="isSaving"
+            @click="onSaveProjectsDir"
+          />
+        </div>
+      </div>
+
+      <div class="flex min-w-0 flex-col gap-3 border-t border-surface-700 pt-3">
+        <!-- Auto-launch toggle. Aligned label + switch with a hint below. -->
+        <div class="flex min-w-0 flex-col gap-1">
+          <label
+            for="jxscout-auto-launch"
+            class="flex items-center justify-between gap-3"
+          >
+            <span
+              class="text-sm font-medium text-surface-700 dark:text-surface-200"
+              >Auto-launch</span
+            >
+            <ToggleSwitch
+              input-id="jxscout-auto-launch"
+              :model-value="autoLaunchOn"
+              @update:model-value="onAutoLaunchToggle"
+            />
+          </label>
+          <p
+            class="m-0 text-xs text-surface-500 dark:text-surface-400 leading-snug"
+          >
+            Start jxscout when Caido opens — no need to visit this page.
+          </p>
+        </div>
+
+        <!-- Auto-sync toggle. -->
+        <div class="flex min-w-0 flex-col gap-1">
+          <label
+            for="jxscout-auto-sync"
+            class="flex items-center justify-between gap-3"
+          >
+            <span
+              class="text-sm font-medium text-surface-700 dark:text-surface-200"
+              >Auto-sync</span
+            >
+            <ToggleSwitch
+              input-id="jxscout-auto-sync"
+              :model-value="autoSyncOn"
+              @update:model-value="onAutoSyncToggle"
+            />
+          </label>
+          <p
+            class="m-0 text-xs text-surface-500 dark:text-surface-400 leading-snug"
+          >
+            Follow the current Caido project. Restarts jxscout with a new
+            <code class="font-mono">--project-name</code> when you switch projects;
+            stops jxscout when the Caido project is closed.
+          </p>
+        </div>
+      </div>
+
+      <div class="flex min-w-0 flex-col gap-1 border-t border-surface-700 pt-3">
+        <span
+          class="text-sm font-medium text-surface-700 dark:text-surface-200"
+          >Binary path</span
+        >
+        <template
+          v-if="binary.detection.value && binary.detection.value.source"
+        >
+          <p
+            class="m-0 text-xs text-surface-500 dark:text-surface-400 leading-snug"
+          >
+            Current ({{ binary.detection.value.source }}):
+          </p>
+          <!-- Block-level <code> with [overflow-wrap:anywhere] so very long
+               paths break at any character without expanding the flex column.
+               The inline <code class="break-all"> approach didn't propagate to
+               the surrounding <p>'s width calc and overflowed the card. -->
+          <code
+            class="block w-full min-w-0 break-all font-mono text-xs text-surface-500 dark:text-surface-400 leading-snug [overflow-wrap:anywhere]"
+            >{{ binary.detection.value.path }}</code
+          >
+        </template>
+        <p
+          v-else
+          class="m-0 text-xs text-surface-500 dark:text-surface-400 leading-snug"
+        >
+          No binary detected.
+        </p>
+        <div class="flex justify-end gap-2 pt-1">
+          <Button
+            v-if="settingsState.settings.value.customBinaryPath"
+            label="Clear custom path"
+            severity="secondary"
+            text
+            size="small"
+            @click="onClearCustomPath"
+          />
+          <Button
+            label="Change binary path…"
+            severity="secondary"
+            size="small"
+            @click="onChangeBinary"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Inline BIN-3, reused from BinarySetup. After a successful validate +
+         save, BinarySetup refreshes binary state; we just close ourselves. -->
+    <div v-else class="border-t border-surface-700 p-3">
+      <BinarySetup initial-view="specify" @back="onBinaryEditBack" />
+    </div>
+  </details>
+</template>

--- a/packages/frontend/src/components/ModeCards.vue
+++ b/packages/frontend/src/components/ModeCards.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import type { Mode } from "backend";
+
+defineProps<{
+  mode: Mode;
+  isPro: boolean;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "select", mode: Mode): void;
+}>();
+
+const select = (next: Mode) => {
+  emit("select", next);
+};
+</script>
+
+<template>
+  <div class="grid grid-cols-2 gap-2">
+    <button
+      type="button"
+      :disabled="disabled"
+      class="relative flex flex-col items-start text-left rounded-md border bg-surface-800 p-3 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+      :class="
+        mode === 'manual'
+          ? 'border-success-500/70 ring-1 ring-success-500/30'
+          : 'border-surface-600 hover:bg-surface-700'
+      "
+      @click="select('manual')"
+    >
+      <h5
+        class="m-0 mb-1 text-sm font-semibold flex items-center gap-2 text-surface-800 dark:text-white/80"
+      >
+        <span
+          v-if="mode === 'manual'"
+          class="inline-block w-2 h-2 rounded-full bg-success-500"
+          aria-hidden="true"
+        ></span>
+        Manual
+      </h5>
+      <p
+        class="m-0 text-sm text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Run jxscout yourself, point the plugin at its host/port.
+      </p>
+    </button>
+
+    <button
+      type="button"
+      :disabled="disabled"
+      class="relative flex flex-col items-start text-left rounded-md border bg-surface-800 p-3 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+      :class="[
+        mode === 'managed'
+          ? 'border-secondary-500/70 ring-1 ring-secondary-500/30'
+          : 'border-surface-600 hover:bg-surface-700',
+      ]"
+      @click="select('managed')"
+    >
+      <span
+        v-if="!isPro"
+        class="absolute top-2 right-2 text-xs font-semibold tracking-wide px-1.5 py-0.5 rounded bg-secondary-500/20 text-secondary-300"
+      >
+        PRO
+      </span>
+      <h5
+        class="m-0 mb-1 text-sm font-semibold flex items-center gap-2 text-surface-800 dark:text-white/80"
+      >
+        <span
+          v-if="mode === 'managed'"
+          class="inline-block w-2 h-2 rounded-full bg-secondary-500"
+          aria-hidden="true"
+        ></span>
+        Managed
+      </h5>
+      <p
+        class="m-0 text-sm text-surface-500 dark:text-surface-400 leading-snug pr-10"
+      >
+        Plugin launches jxscout — stop/restart from this panel. Auto-syncs with
+        Caido projects.
+      </p>
+    </button>
+  </div>
+</template>

--- a/packages/frontend/src/components/ProjectPicker.vue
+++ b/packages/frontend/src/components/ProjectPicker.vue
@@ -1,0 +1,316 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import InputText from "primevue/inputtext";
+import { computed, nextTick, ref, watch } from "vue";
+
+import { useJxscoutProjects } from "@/composables/useJxscoutProjects";
+import { useManualProject } from "@/composables/useManualProject";
+import { useSupervisor } from "@/composables/useSupervisor";
+import { useSDK } from "@/plugins/sdk";
+
+// Phase 10: manual project picker (Auto-sync OFF only). Lives inline on the
+// ManagedRunning card, replacing the static "Project: <name>" row. Click the
+// project name to open the picker; pick an existing one OR type a new one;
+// Apply -> setManualProject + restartJxscout.
+//
+// Free-form names are accepted as-is and normalized on the backend; jxscout-rs
+// creates the project directory on first spawn for names it hasn't seen. The
+// picker doesn't try to validate against the /projects list -- the list is a
+// convenience, not a constraint.
+//
+// Closure semantics match ConfirmModeSwitchDialog: Esc + click-outside both
+// dismiss without applying. Default focus on the search input so the user can
+// start typing immediately.
+
+const props = defineProps<{
+  // The project name to render in the trigger button. Usually status?.project
+  // (live from /health) -- falls back to "(unknown)" while the first poll is
+  // in flight.
+  currentName: string | null;
+  // Whether the manual override is active (drives the "(manual)" badge).
+  hasManualOverride: boolean;
+}>();
+
+const sdk = useSDK();
+const supervisor = useSupervisor();
+const projects = useJxscoutProjects();
+const manualProject = useManualProject();
+
+const open = ref(false);
+const search = ref("");
+const newName = ref("");
+const isApplying = ref(false);
+const searchInputRef = ref<InstanceType<typeof InputText> | null>(null);
+
+const filtered = computed(() => {
+  const list = projects.projects.value ?? [];
+  const q = search.value.trim().toLowerCase();
+  if (q.length === 0) return list;
+  return list.filter((p) => p.name.toLowerCase().includes(q));
+});
+
+// "Use new project name" is only meaningful when the typed value isn't blank
+// and doesn't exactly match an entry in the list (where the user could just
+// click the entry instead).
+const newNameTrimmed = computed(() => newName.value.trim());
+const canApplyNew = computed(() => {
+  if (newNameTrimmed.value.length === 0) return false;
+  const list = projects.projects.value ?? [];
+  return !list.some((p) => p.name === newNameTrimmed.value);
+});
+
+const onOpen = async () => {
+  open.value = true;
+  search.value = "";
+  newName.value = "";
+  // Lazy fetch on open with the 5s cache built into the composable. The user
+  // is unlikely to re-open the picker within that window; if they do we save
+  // a round-trip.
+  void projects.fetchIfStale();
+  // Focus the search input so the user can type immediately. nextTick waits
+  // for v-if to mount the DOM; $el is PrimeVue's wrapped <input>.
+  await nextTick();
+  const el = (searchInputRef.value as unknown as { $el?: HTMLInputElement })
+    ?.$el;
+  if (el && typeof el.focus === "function") el.focus();
+};
+
+const onClose = () => {
+  open.value = false;
+};
+
+const onKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    onClose();
+  }
+};
+
+// The actual apply path: persist the override, then restart the supervisor
+// so it rebinds. Reuses the auto-sync 'switching' event under the hood --
+// restartJxscoutHandler doesn't fire that event itself, so we don't bother
+// trying to wire up a transient pill here; the supervisor's running -> stopped
+// -> starting -> running cycle is short enough (~420ms) that the user sees
+// the picker close, the ManagedRunning card briefly drop, and the new project
+// in place.
+const applyName = async (name: string) => {
+  if (isApplying.value) return;
+  isApplying.value = true;
+  try {
+    const ok = await manualProject.set(name);
+    if (!ok) return;
+    onClose();
+    const restartResp = await supervisor.restart();
+    if (!restartResp.success) {
+      sdk.window.showToast(
+        `Failed to restart jxscout: ${restartResp.error}`,
+        { variant: "error" }
+      );
+    }
+  } finally {
+    isApplying.value = false;
+  }
+};
+
+const onPickExisting = (name: string) => {
+  void applyName(name);
+};
+
+const onApplyNew = () => {
+  const name = newNameTrimmed.value;
+  if (!canApplyNew.value) return;
+  void applyName(name);
+};
+
+// "Clear override" -- only visible when hasManualOverride is true. Falls
+// back to following Caido's current project on the next Start/Restart (per
+// resolveStartArgs).
+const onClearOverride = async () => {
+  if (isApplying.value) return;
+  isApplying.value = true;
+  try {
+    const ok = await manualProject.set(null);
+    if (!ok) return;
+    onClose();
+    const restartResp = await supervisor.restart();
+    if (!restartResp.success) {
+      sdk.window.showToast(
+        `Failed to restart jxscout: ${restartResp.error}`,
+        { variant: "error" }
+      );
+    }
+  } finally {
+    isApplying.value = false;
+  }
+};
+
+// Reset transient state when the picker closes externally (Esc / click-out).
+watch(open, (next) => {
+  if (!next) {
+    search.value = "";
+    newName.value = "";
+  }
+});
+</script>
+
+<template>
+  <span class="inline-flex min-w-0 items-center gap-1.5">
+    <!-- Inline trigger: looks like a clickable text label, matches the visual
+         weight of the other meta-row values. text-style PrimeVue Button keeps
+         it from feeling like a heavy CTA. Truncates if the project name is
+         absurdly long. -->
+    <button
+      type="button"
+      class="min-w-0 truncate rounded-sm px-1 py-0.5 text-left text-sm text-surface-700 underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/60 dark:text-surface-200"
+      :disabled="isApplying"
+      @click="onOpen"
+    >
+      {{ currentName ?? "—" }}
+    </button>
+    <span
+      v-if="hasManualOverride"
+      class="inline-flex items-center rounded bg-surface-700 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-surface-300 dark:bg-surface-700 dark:text-surface-300"
+      title="Bound to a manually picked project, not Caido's current project"
+    >
+      manual
+    </span>
+
+    <Teleport to="body">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        role="presentation"
+        @click.self="onClose"
+        @keydown="onKeydown"
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="project-picker-title"
+          class="flex w-full max-w-sm flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-4 shadow-xl"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <h4
+              id="project-picker-title"
+              class="m-0 text-base font-semibold text-surface-800 dark:text-white/90"
+            >
+              Pick a project
+            </h4>
+            <Button
+              severity="secondary"
+              text
+              size="small"
+              icon="pi pi-refresh"
+              :loading="projects.isLoading.value"
+              aria-label="Refresh project list"
+              @click="projects.refresh()"
+            />
+          </div>
+
+          <InputText
+            ref="searchInputRef"
+            v-model="search"
+            placeholder="Search projects..."
+            class="box-border"
+            fluid
+            size="small"
+          />
+
+          <!-- Scrollable list. Caps height so the picker doesn't dominate
+               smaller viewports; the existing per-row truncation keeps long
+               names from overflowing. -->
+          <div class="max-h-64 min-h-[8rem] overflow-y-auto rounded border border-surface-700 bg-surface-900/50">
+            <template v-if="projects.projects.value === null">
+              <div class="px-3 py-4 text-center text-sm text-surface-500 dark:text-surface-400">
+                <template v-if="projects.isLoading.value">
+                  Loading...
+                </template>
+                <template v-else>
+                  (jxscout not responding)
+                </template>
+              </div>
+            </template>
+            <template v-else-if="filtered.length === 0">
+              <div class="px-3 py-4 text-center text-sm text-surface-500 dark:text-surface-400">
+                <template v-if="(projects.projects.value ?? []).length === 0">
+                  No projects yet
+                </template>
+                <template v-else>
+                  No matches
+                </template>
+              </div>
+            </template>
+            <template v-else>
+              <button
+                v-for="p in filtered"
+                :key="p.name"
+                type="button"
+                class="flex w-full min-w-0 flex-col items-start gap-0.5 border-b border-surface-700 px-3 py-2 text-left last:border-b-0 hover:bg-surface-700/60 focus:bg-surface-700/60 focus:outline-none disabled:opacity-50"
+                :disabled="isApplying"
+                @click="onPickExisting(p.name)"
+              >
+                <span class="flex w-full min-w-0 items-center gap-2">
+                  <span class="truncate text-sm font-medium text-surface-700 dark:text-surface-200">
+                    {{ p.name }}
+                  </span>
+                  <span
+                    v-if="currentName === p.name"
+                    class="inline-flex items-center rounded bg-success-500/20 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-success-300"
+                  >
+                    current
+                  </span>
+                </span>
+                <code class="block min-w-0 truncate font-mono text-[11px] text-surface-500 dark:text-surface-400 [overflow-wrap:anywhere]">
+                  {{ p.path }}
+                </code>
+              </button>
+            </template>
+          </div>
+
+          <div class="flex flex-col gap-2 border-t border-surface-700 pt-3">
+            <span class="text-xs text-surface-500 dark:text-surface-400">
+              Or use a new project name (created on first ingest):
+            </span>
+            <div class="flex gap-2">
+              <InputText
+                v-model="newName"
+                placeholder="my-new-project"
+                class="box-border flex-1 font-mono"
+                fluid
+                size="small"
+                @keydown.enter="onApplyNew"
+              />
+              <Button
+                label="Apply"
+                size="small"
+                :disabled="!canApplyNew || isApplying"
+                :loading="isApplying"
+                @click="onApplyNew"
+              />
+            </div>
+          </div>
+
+          <div class="flex items-center justify-between gap-2 border-t border-surface-700 pt-3">
+            <Button
+              v-if="hasManualOverride"
+              severity="secondary"
+              text
+              size="small"
+              label="Clear override"
+              :disabled="isApplying"
+              @click="onClearOverride"
+            />
+            <span v-else />
+            <Button
+              severity="secondary"
+              text
+              size="small"
+              label="Cancel"
+              @click="onClose"
+            />
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </span>
+</template>

--- a/packages/frontend/src/components/ScopeSettings.vue
+++ b/packages/frontend/src/components/ScopeSettings.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import Textarea from "primevue/textarea";
+import { ref, watch } from "vue";
+
+import { useScope } from "@/composables/useScope";
+import { useSDK } from "@/plugins/sdk";
+
+// User-managed scope: host glob patterns shown directly under the status card
+// in Managed views so users can flip patterns quickly without digging into a
+// drawer. Source of truth is jxscout's per-project settings.jsonc -- the
+// composable fetches it on every supervisor->running transition (incl.
+// project switch) and seeds the textareas. Save pushes back via POST /scope.
+const sdk = useSDK();
+const scope = useScope();
+
+const manualInScopeText = ref("");
+const manualOutOfScopeText = ref("");
+const isSavingScope = ref(false);
+
+// Hydrate the textareas from whichever scope the composable has fetched.
+// Fires on first arrival and on every project switch (the composable clears
+// the ref on supervisor->stopped and refills it on supervisor->running).
+// `null` -> blank textareas, which is the right state both pre-fetch and
+// when no supervisor is running.
+watch(
+  () => scope.fetchedScope.value,
+  (next) => {
+    manualInScopeText.value = next ? next.in_scope.join("\n") : "";
+    manualOutOfScopeText.value = next ? next.out_of_scope.join("\n") : "";
+  },
+  { immediate: true }
+);
+
+const parsePatterns = (raw: string): string[] =>
+  raw
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const onSaveManualScope = async () => {
+  isSavingScope.value = true;
+  try {
+    const in_scope = parsePatterns(manualInScopeText.value);
+    const out_of_scope = parsePatterns(manualOutOfScopeText.value);
+    const pushed = await scope.pushPatterns(in_scope, out_of_scope);
+    if (pushed) {
+      sdk.window.showToast("Scope saved", { variant: "success" });
+    }
+  } finally {
+    isSavingScope.value = false;
+  }
+};
+</script>
+
+<template>
+  <div
+    class="flex min-w-0 flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-3"
+  >
+    <div class="flex min-w-0 flex-col gap-1">
+      <label
+        for="jxscout-manual-in-scope"
+        class="text-sm font-medium text-surface-700 dark:text-surface-200"
+        >in_scope</label
+      >
+      <Textarea
+        id="jxscout-manual-in-scope"
+        v-model="manualInScopeText"
+        class="box-border font-mono"
+        rows="3"
+        placeholder="*.example.com&#10;api.example.com"
+        :disabled="isSavingScope || scope.isFetching.value"
+        fluid
+      />
+      <p
+        class="m-0 text-xs text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Host glob patterns to process. One per line.
+      </p>
+    </div>
+    <div class="flex min-w-0 flex-col gap-1">
+      <label
+        for="jxscout-manual-out-of-scope"
+        class="text-sm font-medium text-surface-700 dark:text-surface-200"
+        >out_of_scope</label
+      >
+      <Textarea
+        id="jxscout-manual-out-of-scope"
+        v-model="manualOutOfScopeText"
+        class="box-border font-mono"
+        rows="3"
+        placeholder="cdn.example.com&#10;*.internal.com"
+        :disabled="isSavingScope || scope.isFetching.value"
+        fluid
+      />
+      <p
+        class="m-0 text-xs text-surface-500 dark:text-surface-400 leading-snug"
+      >
+        Host glob patterns to exclude. One per line.
+      </p>
+    </div>
+    <div class="flex justify-end pt-1">
+      <Button
+        label="Save scope"
+        severity="secondary"
+        size="small"
+        :loading="isSavingScope"
+        :disabled="scope.isFetching.value"
+        @click="onSaveManualScope"
+      />
+    </div>
+  </div>
+</template>

--- a/packages/frontend/src/components/StatusCard.vue
+++ b/packages/frontend/src/components/StatusCard.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import { computed, onScopeDispose, ref } from "vue";
+
+import { useJxscoutStatus } from "@/composables/useJxscoutStatus";
+import { useSDK } from "@/plugins/sdk";
+
+const sdk = useSDK();
+const { status, lastChecked, isFetching, reconnect } = useJxscoutStatus();
+
+// Drives the "last ping Xs" ticker; settle for 0.5s granularity so the
+// number changes visibly without burning render cycles.
+const now = ref(Date.now());
+const tick = setInterval(() => {
+  now.value = Date.now();
+}, 500);
+onScopeDispose(() => clearInterval(tick));
+
+const lastPingLabel = computed(() => {
+  if (lastChecked.value === null) return "—";
+  const seconds = Math.max(0, (now.value - lastChecked.value) / 1000);
+  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
+});
+
+const onReconnect = () => {
+  void reconnect();
+};
+
+// "Open in <tool>" buttons under the working-dir row. Each routes through the
+// backend openPath RPC, which spawns the platform-native launcher (open /
+// explorer / xdg-open) or the editor's `code`/`cursor` CLI helper. Surfacing
+// the launch error as a toast helps users diagnose missing CLI installs.
+const onOpenWorkingDir = async (tool: "folder" | "vscode" | "cursor") => {
+  const dir = status.value?.working_directory;
+  if (!dir) return;
+  const result = await sdk.backend.openPath({ path: dir, tool });
+  if (!result.success) {
+    sdk.window.showToast(result.error, { variant: "error" });
+  }
+};
+</script>
+
+<template>
+  <div
+    v-if="status"
+    class="flex flex-col gap-3 rounded-md border border-surface-600 bg-surface-800 p-3 ring-1 ring-success-500/30"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full bg-success-500/15 px-2 py-0.5 text-xs font-medium text-success-300"
+      >
+        <span
+          class="inline-block h-1.5 w-1.5 rounded-full bg-success-500"
+          aria-hidden="true"
+        ></span>
+        Connected
+      </span>
+      <span class="text-xs text-surface-500 dark:text-surface-400">
+        v{{ status.version }} · last ping {{ lastPingLabel }}
+      </span>
+    </div>
+
+    <div class="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-sm">
+      <span class="text-surface-500 dark:text-surface-400">Project:</span>
+      <span class="truncate text-surface-700 dark:text-surface-200">
+        {{ status.project }}
+      </span>
+      <span class="text-surface-500 dark:text-surface-400">Working dir:</span>
+      <div v-if="status.working_directory" class="min-w-0 flex flex-col gap-1">
+        <code
+          class="block min-w-0 break-all font-mono text-xs text-surface-700 dark:text-surface-200 [overflow-wrap:anywhere]"
+          >{{ status.working_directory }}</code
+        >
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+          <button
+            type="button"
+            class="text-info-400 hover:underline"
+            @click="onOpenWorkingDir('folder')"
+          >
+            Open folder
+          </button>
+          <span class="text-surface-500 dark:text-surface-400" aria-hidden="true">·</span>
+          <button
+            type="button"
+            class="text-info-400 hover:underline"
+            @click="onOpenWorkingDir('vscode')"
+          >
+            VS Code
+          </button>
+          <span class="text-surface-500 dark:text-surface-400" aria-hidden="true">·</span>
+          <button
+            type="button"
+            class="text-info-400 hover:underline"
+            @click="onOpenWorkingDir('cursor')"
+          >
+            Cursor
+          </button>
+        </div>
+      </div>
+      <span
+        v-else
+        class="truncate font-mono text-xs text-surface-700 dark:text-surface-200"
+      >
+        —
+      </span>
+    </div>
+
+    <div class="flex justify-end">
+      <Button
+        label="Reconnect"
+        severity="secondary"
+        text
+        size="small"
+        :loading="isFetching"
+        @click="onReconnect"
+      />
+    </div>
+  </div>
+</template>

--- a/packages/frontend/src/composables/useAutoSync.ts
+++ b/packages/frontend/src/composables/useAutoSync.ts
@@ -1,0 +1,109 @@
+import {
+  type InjectionKey,
+  type Ref,
+  inject,
+  onScopeDispose,
+  provide,
+  ref,
+  watch,
+} from "vue";
+
+import { useSDK } from "@/plugins/sdk";
+
+// Phase 8: transient "Switching project..." indicator. The backend emits an
+// `auto-sync` event whenever `onProjectChange` triggers a side effect; the
+// frontend turns that into a temporary status pill on the Managed cards.
+//
+// Backend payload shape -- kept loose here so the consumer doesn't have to
+// import the backend type; the `kind` discriminator is the only field UIs
+// actually branch on.
+type AutoSyncEvent =
+  | { kind: "switching"; from: string | null; to: string }
+  | { kind: "stopping"; from: string | null };
+
+// Pill lifetime. Long enough to read; short enough that it doesn't linger past
+// the supervisor's typical stopped -> starting -> running cycle (~500-1000ms
+// in practice). Independent of supervisor state changes -- the pill is purely
+// a transient affordance for "yes, we noticed the project change".
+const PILL_LIFETIME_MS = 1500;
+
+export type AutoSyncState = {
+  event: Ref<AutoSyncEvent | null>;
+};
+
+const KEY: InjectionKey<AutoSyncState> = Symbol("AutoSyncState");
+
+// Mirrors useSupervisor's enable-gating: only subscribe when the user is in
+// managed mode and Pro. Free / Manual users never see an auto-sync event.
+const createAutoSyncState = (enabled: Ref<boolean>): AutoSyncState => {
+  const sdk = useSDK();
+
+  const event = ref<AutoSyncEvent | null>(null);
+  let unsubscribe: { stop: () => void } | null = null;
+  let clearTimer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+
+  const clearAfter = (ms: number) => {
+    if (clearTimer !== null) clearTimeout(clearTimer);
+    clearTimer = setTimeout(() => {
+      if (disposed) return;
+      event.value = null;
+      clearTimer = null;
+    }, ms);
+  };
+
+  const subscribe = () => {
+    if (unsubscribe) return;
+    unsubscribe = sdk.backend.onEvent("auto-sync", (next: AutoSyncEvent) => {
+      if (disposed) return;
+      event.value = next;
+      clearAfter(PILL_LIFETIME_MS);
+    });
+  };
+
+  const teardown = () => {
+    if (unsubscribe) {
+      try {
+        unsubscribe.stop();
+      } catch {
+        // swallow
+      }
+      unsubscribe = null;
+    }
+    if (clearTimer !== null) {
+      clearTimeout(clearTimer);
+      clearTimer = null;
+    }
+    event.value = null;
+  };
+
+  watch(
+    enabled,
+    (on) => {
+      if (on) subscribe();
+      else teardown();
+    },
+    { immediate: true }
+  );
+
+  onScopeDispose(() => {
+    disposed = true;
+    teardown();
+  });
+
+  return { event };
+};
+
+export const provideAutoSync = (enabled: Ref<boolean>): AutoSyncState => {
+  const state = createAutoSyncState(enabled);
+  provide(KEY, state);
+  return state;
+};
+
+export const useAutoSync = (): AutoSyncState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error("useAutoSync() called without a provideAutoSync() ancestor");
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useBinary.ts
+++ b/packages/frontend/src/composables/useBinary.ts
@@ -1,0 +1,126 @@
+import {
+  type InjectionKey,
+  type Ref,
+  computed,
+  inject,
+  onScopeDispose,
+  provide,
+  ref,
+  watch,
+} from "vue";
+import type { DetectionResult, ReleaseType } from "backend";
+
+import { useSDK } from "@/plugins/sdk";
+
+export type BinaryState = {
+  detection: Ref<DetectionResult | null>;
+  isLoading: Ref<boolean>;
+  isLoaded: Ref<boolean>;
+  hasBinary: Ref<boolean>;
+  releaseType: Ref<ReleaseType | null>;
+  releaseTypeLoaded: Ref<boolean>;
+  refresh: () => Promise<void>;
+};
+
+const KEY: InjectionKey<BinaryState> = Symbol("BinaryState");
+
+// `enabled` follows the Phase 4/6 convention: don't fire detection until the
+// user is confirmed Pro and in managed mode. Free / Manual users never even
+// shell out to `which`. Refreshing on detection re-runs the full discovery
+// pipeline (custom -> PATH -> managed).
+const createBinaryState = (enabled: Ref<boolean>): BinaryState => {
+  const sdk = useSDK();
+
+  const detection = ref<DetectionResult | null>(null);
+  const isLoading = ref(false);
+  const isLoaded = ref(false);
+  const releaseType = ref<ReleaseType | null>(null);
+  const releaseTypeLoaded = ref(false);
+
+  const hasBinary = computed(() =>
+    detection.value !== null && detection.value.source !== null
+  );
+
+  const refresh = async () => {
+    isLoading.value = true;
+    try {
+      const result = await sdk.backend.detectBinary();
+      detection.value = result;
+      isLoaded.value = true;
+    } catch (err) {
+      sdk.window.showToast(`Failed to detect binary: ${err}`, {
+        variant: "error",
+      });
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  // releaseType is host-platform-only; doesn't change at runtime. Fetch
+  // once on first enable, cache. Used by BIN-1 to show the right platform
+  // label and to surface the "unsupported platform" hard-fail.
+  const loadReleaseType = async () => {
+    if (releaseTypeLoaded.value) return;
+    try {
+      const r = await sdk.backend.getReleaseType();
+      releaseType.value = r;
+      releaseTypeLoaded.value = true;
+    } catch (err) {
+      // Frontend SDK has no `console`; the error is rare (only fires if the
+      // RPC layer itself blows up) and not actionable for the user.
+      console.error(`Failed to load release type: ${err}`);
+    }
+  };
+
+  watch(
+    enabled,
+    (on) => {
+      if (on) {
+        void refresh();
+        void loadReleaseType();
+      }
+    },
+    { immediate: true }
+  );
+
+  // Re-run detection when the Caido tab regains focus. The discovery pipeline
+  // (custom path -> PATH -> managed) reflects the live filesystem + $PATH, so
+  // a user who removed the binary from PATH while Caido was backgrounded sees
+  // the stale entry replaced as soon as they refocus. Mirrors useLicense's
+  // focus refresh -- same trade-off: rare event, cheap RPC, no polling.
+  const onFocus = () => {
+    if (!enabled.value) return;
+    void refresh();
+  };
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("focus", onFocus);
+    onScopeDispose(() => {
+      window.removeEventListener("focus", onFocus);
+    });
+  }
+
+  return {
+    detection,
+    isLoading,
+    isLoaded,
+    hasBinary,
+    releaseType,
+    releaseTypeLoaded,
+    refresh,
+  };
+};
+
+export const provideBinary = (enabled: Ref<boolean>): BinaryState => {
+  const state = createBinaryState(enabled);
+  provide(KEY, state);
+  return state;
+};
+
+export const useBinary = (): BinaryState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error("useBinary() called without a provideBinary() ancestor");
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useJxscoutProjects.ts
+++ b/packages/frontend/src/composables/useJxscoutProjects.ts
@@ -1,0 +1,84 @@
+import {
+  type InjectionKey,
+  type Ref,
+  inject,
+  provide,
+  ref,
+} from "vue";
+import type { ProjectEntry } from "backend";
+
+import { useSDK } from "@/plugins/sdk";
+
+// Phase 10: lazy-fetch known jxscout projects when the picker opens. No
+// continuous polling -- the user only sees this list while they have the
+// picker open, so a fresh fetch each open is cheap and avoids stale state
+// after a free-form Apply creates a new project on the jxscout side. We
+// cache for 5s purely so multiple consumers opening the picker back-to-back
+// don't double-fetch.
+
+const STALE_AFTER_MS = 5000;
+
+export type JxscoutProjectsState = {
+  projects: Ref<ProjectEntry[] | null>;
+  isLoading: Ref<boolean>;
+  error: Ref<string | null>;
+  refresh: () => Promise<void>;
+  // Returns cached data immediately if still fresh, otherwise triggers a
+  // refresh. Callers (e.g. the picker's popover @show handler) use this so
+  // a re-open within 5s doesn't double-fetch.
+  fetchIfStale: () => Promise<void>;
+};
+
+const KEY: InjectionKey<JxscoutProjectsState> = Symbol("JxscoutProjectsState");
+
+const createJxscoutProjectsState = (): JxscoutProjectsState => {
+  const sdk = useSDK();
+
+  // null distinguishes "never fetched" / "supervisor not running" from
+  // "fetched, empty list". The picker renders these cases differently --
+  // "(jxscout not responding)" vs "no projects yet".
+  const projects = ref<ProjectEntry[] | null>(null);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+  let lastFetchedAt = 0;
+
+  const refresh = async () => {
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const result = await sdk.backend.listJxscoutProjects();
+      projects.value = result;
+      lastFetchedAt = Date.now();
+    } catch (err) {
+      error.value = `${err}`;
+      projects.value = null;
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const fetchIfStale = async () => {
+    if (Date.now() - lastFetchedAt < STALE_AFTER_MS && projects.value !== null) {
+      return;
+    }
+    await refresh();
+  };
+
+  return { projects, isLoading, error, refresh, fetchIfStale };
+};
+
+export const provideJxscoutProjects = (): JxscoutProjectsState => {
+  const state = createJxscoutProjectsState();
+  provide(KEY, state);
+  return state;
+};
+
+export const useJxscoutProjects = (): JxscoutProjectsState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error(
+      "useJxscoutProjects() called without a provideJxscoutProjects() ancestor"
+    );
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useJxscoutStatus.ts
+++ b/packages/frontend/src/composables/useJxscoutStatus.ts
@@ -1,0 +1,157 @@
+import {
+  type InjectionKey,
+  type Ref,
+  inject,
+  onScopeDispose,
+  provide,
+  ref,
+  watch,
+} from "vue";
+import type { JxscoutStatus, Settings } from "backend";
+
+import { useSDK } from "@/plugins/sdk";
+
+const POLL_INTERVAL_MS = 3000;
+
+export type JxscoutStatusState = {
+  status: Ref<JxscoutStatus | null>;
+  lastChecked: Ref<number | null>;
+  isFetching: Ref<boolean>;
+  reconnect: () => Promise<void>;
+};
+
+const KEY: InjectionKey<JxscoutStatusState> = Symbol("JxscoutStatusState");
+
+// Takes settings + enabled explicitly because provide() and inject() can't be
+// called against the same component instance; App.vue passes them in.
+//
+// `enabled` gates the polling loop -- the composable does nothing while it's
+// false. App.vue sets it to true once both the license is confirmed Pro and
+// the saved settings have loaded, so we never poll with default-but-not-yet-
+// loaded host/port and never burn cycles for free users.
+//
+// `portOverride` carries Managed mode's actual session port (snapshot.port).
+// Managed mode auto-allocates and binds 127.0.0.1 so we ignore settings.host
+// in that case too; null override means "no live supervisor" and we fall
+// back to the manual-mode host/port the user typed in.
+const createJxscoutStatusState = (
+  settings: Ref<Settings>,
+  enabled: Ref<boolean>,
+  portOverride: Ref<number | null>
+): JxscoutStatusState => {
+  const sdk = useSDK();
+
+  const status = ref<JxscoutStatus | null>(null);
+  const lastChecked = ref<number | null>(null);
+  const isFetching = ref(false);
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const effectivePort = (): number => {
+    const override = portOverride.value;
+    return typeof override === "number" && override > 0
+      ? override
+      : settings.value.port;
+  };
+
+  const effectiveHost = (): string => {
+    // Managed mode (portOverride present) -> supervisor always binds
+    // 127.0.0.1, regardless of what's in settings.host (which is the
+    // manual-mode connection target). Avoids "localhost" / IPv6 / hostname
+    // resolution surprises across parallel Caido instances.
+    const override = portOverride.value;
+    if (typeof override === "number" && override > 0) return "127.0.0.1";
+    return settings.value.host;
+  };
+
+  const fetchOnce = async () => {
+    if (isFetching.value) return;
+    isFetching.value = true;
+    try {
+      const next = await sdk.backend.fetchJxscoutStatus(
+        effectiveHost(),
+        effectivePort()
+      );
+      status.value = next;
+      lastChecked.value = Date.now();
+    } finally {
+      isFetching.value = false;
+    }
+  };
+
+  const scheduleNext = () => {
+    if (stopped || !enabled.value) return;
+    timer = setTimeout(async () => {
+      await fetchOnce();
+      scheduleNext();
+    }, POLL_INTERVAL_MS);
+  };
+
+  const startLoop = async () => {
+    if (stopped || !enabled.value) return;
+    clearTimer();
+    await fetchOnce();
+    scheduleNext();
+  };
+
+  const reconnect = async () => {
+    if (!enabled.value) return;
+    await startLoop();
+  };
+
+  // Start/stop polling whenever the gate flips, then restart on host/port save.
+  watch(
+    enabled,
+    (on) => {
+      if (on) {
+        void startLoop();
+      } else {
+        clearTimer();
+        status.value = null;
+      }
+    },
+    { immediate: true }
+  );
+
+  watch(
+    () => `${effectiveHost()}:${effectivePort()}`,
+    () => {
+      if (enabled.value) void startLoop();
+    }
+  );
+
+  onScopeDispose(() => {
+    stopped = true;
+    clearTimer();
+  });
+
+  return { status, lastChecked, isFetching, reconnect };
+};
+
+export const provideJxscoutStatus = (
+  settings: Ref<Settings>,
+  enabled: Ref<boolean>,
+  portOverride: Ref<number | null>
+): JxscoutStatusState => {
+  const state = createJxscoutStatusState(settings, enabled, portOverride);
+  provide(KEY, state);
+  return state;
+};
+
+export const useJxscoutStatus = (): JxscoutStatusState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error(
+      "useJxscoutStatus() called without a provideJxscoutStatus() ancestor"
+    );
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useLicense.ts
+++ b/packages/frontend/src/composables/useLicense.ts
@@ -1,0 +1,86 @@
+import {
+  type InjectionKey,
+  type Ref,
+  inject,
+  onScopeDispose,
+  provide,
+  ref,
+} from "vue";
+
+import { useSDK } from "@/plugins/sdk";
+
+export type LicenseState = {
+  isPro: Ref<boolean>;
+  isLoading: Ref<boolean>;
+  isLoaded: Ref<boolean>;
+  refresh: () => Promise<void>;
+};
+
+const KEY: InjectionKey<LicenseState> = Symbol("LicenseState");
+
+const createLicenseState = (): LicenseState => {
+  const sdk = useSDK();
+
+  const isPro = ref(false);
+  const isLoading = ref(false);
+  const isLoaded = ref(false);
+
+  const refresh = async () => {
+    isLoading.value = true;
+    try {
+      const response = await sdk.backend.hasLicense();
+      if (response.success) {
+        isPro.value = response.data;
+        isLoaded.value = true;
+      } else {
+        sdk.window.showToast(`Failed to check license: ${response.error}`, {
+          variant: "error",
+        });
+      }
+    } catch (err) {
+      sdk.window.showToast(`Failed to check license: ${err}`, {
+        variant: "error",
+      });
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  // Phase 9: re-check the license file when the Caido tab regains focus.
+  // Catches the user deleting ~/.jxscout-pro/.license externally, or
+  // jxscout-pro-v2 clearing it on a Keygen heartbeat failure. App.vue
+  // watches isPro for a true -> false transition and handles the toast +
+  // supervisor stop side effects -- this composable just owns the source
+  // of truth.
+  //
+  // Plain 'focus' is correct here: it fires when the user navigates back
+  // to the Caido tab from elsewhere, which is the only realistic vector
+  // for an external license change to be relevant to UI state. Polling
+  // on a timer would burn cycles for a rare event.
+  const onFocus = () => {
+    void refresh();
+  };
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("focus", onFocus);
+    onScopeDispose(() => {
+      window.removeEventListener("focus", onFocus);
+    });
+  }
+
+  return { isPro, isLoading, isLoaded, refresh };
+};
+
+export const provideLicense = (): LicenseState => {
+  const state = createLicenseState();
+  provide(KEY, state);
+  return state;
+};
+
+export const useLicense = (): LicenseState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error("useLicense() called without a provideLicense() ancestor");
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useManualProject.ts
+++ b/packages/frontend/src/composables/useManualProject.ts
@@ -1,0 +1,93 @@
+import { type InjectionKey, type Ref, inject, provide, ref } from "vue";
+
+import { useSDK } from "@/plugins/sdk";
+
+// Phase 10 manual project picker state. Lives in this composable rather than
+// useSettings because it's per-Caido-instance: the backend keeps it in
+// module-scope memory only, so we can't piggy-back on settings.json round
+// trips. The picker calls set() to update both sides; the rest of the UI
+// reads `manualProjectName` to render the "(manual)" badge.
+export type ManualProjectState = {
+  manualProjectName: Ref<string | null>;
+  isLoading: Ref<boolean>;
+  // Push a new override to the backend. Returns true on success. Callers
+  // typically follow this with supervisor.restart() to make the override
+  // take effect immediately.
+  set: (name: string | null) => Promise<boolean>;
+  // Pull the backend's current value into our ref. Called once on mount;
+  // available as a manual refresh if the UI ever needs one.
+  load: () => Promise<void>;
+};
+
+const KEY: InjectionKey<ManualProjectState> = Symbol("ManualProjectState");
+
+const createManualProjectState = (): ManualProjectState => {
+  const sdk = useSDK();
+
+  const manualProjectName = ref<string | null>(null);
+  const isLoading = ref(false);
+
+  const load = async (): Promise<void> => {
+    isLoading.value = true;
+    try {
+      const response = await sdk.backend.getManualProject();
+      if (response.success) {
+        manualProjectName.value = response.data.manualProjectName;
+      } else {
+        // Toast would be noisy for an init-time pull -- log only.
+        // eslint-disable-next-line no-console
+        console.error(`Failed to load manual project: ${response.error}`);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to load manual project: ${err}`);
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const set = async (name: string | null): Promise<boolean> => {
+    isLoading.value = true;
+    try {
+      const response = await sdk.backend.setManualProject(name);
+      if (!response.success) {
+        sdk.window.showToast(
+          `Failed to save manual project: ${response.error}`,
+          { variant: "error" }
+        );
+        return false;
+      }
+      manualProjectName.value = response.data.manualProjectName;
+      return true;
+    } catch (err) {
+      sdk.window.showToast(`Failed to save manual project: ${err}`, {
+        variant: "error",
+      });
+      return false;
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  return { manualProjectName, isLoading, set, load };
+};
+
+export const provideManualProject = (): ManualProjectState => {
+  const state = createManualProjectState();
+  provide(KEY, state);
+  // Fire-and-forget initial load. Backend's module-scope state defaults to
+  // null on plugin init so this almost always resolves immediately to null;
+  // worth doing anyway so a survivor of an HMR refresh sees the truth.
+  void state.load();
+  return state;
+};
+
+export const useManualProject = (): ManualProjectState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error(
+      "useManualProject() called without a provideManualProject() ancestor"
+    );
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useScope.ts
+++ b/packages/frontend/src/composables/useScope.ts
@@ -1,0 +1,122 @@
+import { type InjectionKey, type Ref, inject, provide, ref, watch } from "vue";
+
+import type { SupervisorState } from "@/composables/useSupervisor";
+import { useSDK } from "@/plugins/sdk";
+
+export type FetchedScope = {
+  in_scope: string[];
+  out_of_scope: string[];
+};
+
+export type ScopeState = {
+  // Latest scope read from jxscout's GET /scope, refreshed on every
+  // supervisor->running transition. `null` before the first successful fetch
+  // (or while the supervisor is offline) -- ScopeSettings.vue uses that to
+  // decide whether to seed its textareas.
+  fetchedScope: Ref<FetchedScope | null>;
+  // True while a fetch is in flight. Lets ScopeSettings disable its inputs
+  // so the user doesn't type into a textarea that's about to be overwritten.
+  isFetching: Ref<boolean>;
+  // Push explicit patterns. Used by ScopeSettings.vue's Save button so typed
+  // values land in jxscout immediately.
+  pushPatterns: (in_scope: string[], out_of_scope: string[]) => Promise<boolean>;
+  // Manual refresh hook. Currently unused by consumers but kept so the UI can
+  // expose a "reload" affordance if we ever want one without re-plumbing.
+  refresh: () => Promise<void>;
+};
+
+const KEY: InjectionKey<ScopeState> = Symbol("ScopeState");
+
+const createScopeState = (supervisor: SupervisorState): ScopeState => {
+  const sdk = useSDK();
+
+  const fetchedScope = ref<FetchedScope | null>(null);
+  const isFetching = ref(false);
+
+  const refresh = async (): Promise<void> => {
+    isFetching.value = true;
+    try {
+      const response = await sdk.backend.fetchScope();
+      if (!response.success) {
+        sdk.window.showToast(`Scope fetch failed: ${response.error}`, {
+          variant: "error",
+        });
+        return;
+      }
+      fetchedScope.value = {
+        in_scope: [...response.data.in_scope],
+        out_of_scope: [...response.data.out_of_scope],
+      };
+    } catch (err) {
+      sdk.window.showToast(`Scope fetch failed: ${err}`, { variant: "error" });
+    } finally {
+      isFetching.value = false;
+    }
+  };
+
+  const pushPatterns = async (
+    in_scope: string[],
+    out_of_scope: string[]
+  ): Promise<boolean> => {
+    try {
+      const response = await sdk.backend.pushScope({
+        in_scope,
+        out_of_scope,
+      });
+      if (!response.success) {
+        sdk.window.showToast(`Scope push failed: ${response.error}`, {
+          variant: "error",
+        });
+        return false;
+      }
+      // Optimistically reflect what we just pushed so a subsequent project
+      // change starts from the right baseline without an extra round trip.
+      fetchedScope.value = { in_scope: [...in_scope], out_of_scope: [...out_of_scope] };
+      return true;
+    } catch (err) {
+      sdk.window.showToast(`Scope push failed: ${err}`, { variant: "error" });
+      return false;
+    }
+  };
+
+  // Re-read the *current project's* scope whenever the supervisor transitions
+  // into "running". Covers first Start, auto-launch at plugin init, Restart
+  // (project switch / explicit button), and download/specify-path success.
+  // Replaces an older "push the cached patterns" hook that used to clobber a
+  // freshly-switched project's scope with whichever patterns the user last
+  // saved -- the plugin no longer owns the source of truth.
+  watch(
+    () => supervisor.snapshot.value?.state,
+    (next, prev) => {
+      if (next === "running" && prev !== "running") {
+        void refresh();
+      } else if (next !== "running" && prev === "running") {
+        // Clear when the supervisor goes away so the textareas don't keep
+        // displaying stale patterns from a no-longer-running project.
+        fetchedScope.value = null;
+      }
+    }
+  );
+
+  // First mount: if the supervisor is already running (auto-launch finished
+  // before this composable mounted), seed immediately.
+  if (supervisor.snapshot.value?.state === "running") {
+    void refresh();
+  }
+
+  return { fetchedScope, isFetching, pushPatterns, refresh };
+};
+
+export const provideScope = (supervisor: SupervisorState): ScopeState => {
+  const state = createScopeState(supervisor);
+  provide(KEY, state);
+  return state;
+};
+
+export const useScope = (): ScopeState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error("useScope() called without a provideScope() ancestor");
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useSettings.ts
+++ b/packages/frontend/src/composables/useSettings.ts
@@ -1,0 +1,95 @@
+import { type InjectionKey, type Ref, inject, provide, ref } from "vue";
+import type { Settings } from "backend";
+
+import { useSDK } from "@/plugins/sdk";
+
+const DEFAULT_SETTINGS: Settings = {
+  host: "localhost",
+  port: 3333,
+  filterInScope: false,
+  mode: "manual",
+  customBinaryPath: null,
+  defaultProjectsDir: null,
+  autoLaunch: true,
+  autoSync: true,
+};
+
+export type SettingsState = {
+  settings: Ref<Settings>;
+  isLoading: Ref<boolean>;
+  isLoaded: Ref<boolean>;
+  load: () => Promise<void>;
+  save: (overrides?: Partial<Settings>) => Promise<boolean>;
+};
+
+const KEY: InjectionKey<SettingsState> = Symbol("SettingsState");
+
+const createSettingsState = (): SettingsState => {
+  const sdk = useSDK();
+
+  const settings = ref<Settings>({ ...DEFAULT_SETTINGS });
+  const isLoading = ref(false);
+  const isLoaded = ref(false);
+
+  const load = async () => {
+    isLoading.value = true;
+    try {
+      const response = await sdk.backend.getSettings();
+      if (response.success) {
+        settings.value = response.data;
+        isLoaded.value = true;
+      } else {
+        sdk.window.showToast(`Failed to load settings: ${response.error}`, {
+          variant: "error",
+        });
+      }
+    } catch (err) {
+      sdk.window.showToast(`Failed to load settings: ${err}`, {
+        variant: "error",
+      });
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const save = async (overrides: Partial<Settings> = {}): Promise<boolean> => {
+    isLoading.value = true;
+    try {
+      const payload: Settings = { ...settings.value, ...overrides };
+      const response = await sdk.backend.saveSettings(payload);
+      if (response.success) {
+        settings.value = response.data;
+        return true;
+      }
+      sdk.window.showToast(`Failed to save settings: ${response.error}`, {
+        variant: "error",
+      });
+      return false;
+    } catch (err) {
+      sdk.window.showToast(`Failed to save settings: ${err}`, {
+        variant: "error",
+      });
+      return false;
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  return { settings, isLoading, isLoaded, load, save };
+};
+
+export const provideSettings = (): SettingsState => {
+  const state = createSettingsState();
+  provide(KEY, state);
+  return state;
+};
+
+export const useSettings = (): SettingsState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error(
+      "useSettings() called without a provideSettings() ancestor"
+    );
+  }
+  return state;
+};

--- a/packages/frontend/src/composables/useSupervisor.ts
+++ b/packages/frontend/src/composables/useSupervisor.ts
@@ -1,0 +1,165 @@
+import {
+  type InjectionKey,
+  type Ref,
+  computed,
+  inject,
+  onScopeDispose,
+  provide,
+  ref,
+  watch,
+} from "vue";
+import type {
+  StartResult,
+  StopResult,
+  SupervisorSnapshot,
+} from "backend";
+
+import { useSDK } from "@/plugins/sdk";
+
+// How often to update the derived "uptime" display while running. 500ms
+// matches StatusCard.vue's last-ping ticker; same trade-off (visible
+// granularity without burning render cycles).
+const UPTIME_TICK_MS = 500;
+
+export type SupervisorState = {
+  snapshot: Ref<SupervisorSnapshot | null>;
+  isLoaded: Ref<boolean>;
+  uptimeMs: Ref<number | null>;
+  isBusy: Ref<boolean>;
+  start: () => Promise<StartResult>;
+  stop: () => Promise<StopResult>;
+  restart: () => Promise<StartResult>;
+  refresh: () => Promise<void>;
+};
+
+const KEY: InjectionKey<SupervisorState> = Symbol("SupervisorState");
+
+// `enabled` gates both the initial state fetch and the live event
+// subscription. App.vue sets it true once the user is confirmed Pro AND in
+// managed mode -- mirroring the Phase 4 pattern for useJxscoutStatus. Free
+// users + Manual users never even attach the listener.
+const createSupervisorState = (enabled: Ref<boolean>): SupervisorState => {
+  const sdk = useSDK();
+
+  const snapshot = ref<SupervisorSnapshot | null>(null);
+  const isLoaded = ref(false);
+  const isBusy = ref(false);
+  const now = ref(Date.now());
+
+  let unsubscribe: { stop: () => void } | null = null;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let disposed = false;
+
+  const uptimeMs = computed<number | null>(() => {
+    const snap = snapshot.value;
+    if (!snap || snap.state !== "running" || snap.startedAt === null) {
+      return null;
+    }
+    return Math.max(0, now.value - snap.startedAt);
+  });
+
+  const refresh = async () => {
+    try {
+      const s = await sdk.backend.getSupervisorState();
+      if (disposed) return;
+      snapshot.value = s;
+      isLoaded.value = true;
+    } catch (err) {
+      sdk.window.showToast(`Supervisor: failed to read state: ${err}`, {
+        variant: "error",
+      });
+    }
+  };
+
+  const subscribe = () => {
+    if (unsubscribe) return;
+    unsubscribe = sdk.backend.onEvent("supervisor-state", (next) => {
+      if (disposed) return;
+      snapshot.value = next;
+      isLoaded.value = true;
+    });
+  };
+
+  const teardown = () => {
+    if (unsubscribe) {
+      try {
+        unsubscribe.stop();
+      } catch {
+        // swallow
+      }
+      unsubscribe = null;
+    }
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const start = async (): Promise<StartResult> => {
+    isBusy.value = true;
+    try {
+      return await sdk.backend.startJxscout();
+    } finally {
+      isBusy.value = false;
+    }
+  };
+
+  const stop = async (): Promise<StopResult> => {
+    isBusy.value = true;
+    try {
+      return await sdk.backend.stopJxscout();
+    } finally {
+      isBusy.value = false;
+    }
+  };
+
+  const restart = async (): Promise<StartResult> => {
+    isBusy.value = true;
+    try {
+      return await sdk.backend.restartJxscout();
+    } finally {
+      isBusy.value = false;
+    }
+  };
+
+  watch(
+    enabled,
+    (on) => {
+      if (on) {
+        void refresh();
+        subscribe();
+        if (timer === null) {
+          timer = setInterval(() => {
+            now.value = Date.now();
+          }, UPTIME_TICK_MS);
+        }
+      } else {
+        teardown();
+      }
+    },
+    { immediate: true }
+  );
+
+  onScopeDispose(() => {
+    disposed = true;
+    teardown();
+  });
+
+  return { snapshot, isLoaded, uptimeMs, isBusy, start, stop, restart, refresh };
+};
+
+export const provideSupervisor = (enabled: Ref<boolean>): SupervisorState => {
+  const state = createSupervisorState(enabled);
+  provide(KEY, state);
+  return state;
+};
+
+export const useSupervisor = (): SupervisorState => {
+  const state = inject(KEY);
+  if (!state) {
+    throw new Error(
+      "useSupervisor() called without a provideSupervisor() ancestor"
+    );
+  }
+  return state;
+};

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -31,10 +31,9 @@ export const init = (sdk: FrontendSDK) => {
     width: "100%",
   });
 
-  // Set the ID of the root element
-  // Replace this with the value of the prefixWrap plugin in caido.config.ts 
-  // This is necessary to prevent styling conflicts between plugins
-  root.id = `plugin--frontend-vue`;
+  // ID must match the postcss-prefixwrap selector in caido.config.ts so the
+  // plugin's compiled CSS layer actually targets this subtree.
+  root.id = `plugin--jxscout-caido`;
 
   // Mount the app to the root element
   app.mount(root);

--- a/packages/frontend/src/styles/index.css
+++ b/packages/frontend/src/styles/index.css
@@ -3,3 +3,18 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+
+/* Caido's host shell sets `user-select: none` globally. Re-enable it inside
+ * the plugin; selectors here are bare because postcss-prefixwrap will scope
+ * them to `#plugin--jxscout-caido` at build time — pre-prefixing produces
+ * `#plugin--jxscout-caido #plugin--jxscout-caido *`, which matches nothing. */
+*,
+:root {
+  user-select: text;
+  -webkit-user-select: text;
+}
+.select-none,
+.select-none * {
+  user-select: none;
+  -webkit-user-select: none;
+}

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,4 +1,4 @@
 import { Caido } from "@caido/sdk-frontend";
-import { API } from "backend";
+import { Spec } from "backend";
 
-export type FrontendSDK = Caido<API, {}>;
+export type FrontendSDK = Caido<Spec["api"], Spec["events"]>;

--- a/packages/frontend/src/views/App.vue
+++ b/packages/frontend/src/views/App.vue
@@ -1,84 +1,199 @@
 <script setup lang="ts">
-import Button from "primevue/button";
-import InputText from "primevue/inputtext";
+import type { Mode } from "backend";
+import { computed, onMounted, ref, watch } from "vue";
 
+import ConfirmModeSwitchDialog from "@/components/ConfirmModeSwitchDialog.vue";
+import ModeCards from "@/components/ModeCards.vue";
+import { provideAutoSync } from "@/composables/useAutoSync";
+import { provideBinary } from "@/composables/useBinary";
+import { provideJxscoutProjects } from "@/composables/useJxscoutProjects";
+import { provideJxscoutStatus } from "@/composables/useJxscoutStatus";
+import { provideLicense } from "@/composables/useLicense";
+import { provideManualProject } from "@/composables/useManualProject";
+import { provideScope } from "@/composables/useScope";
+import { provideSettings } from "@/composables/useSettings";
+import { provideSupervisor } from "@/composables/useSupervisor";
 import { useSDK } from "@/plugins/sdk";
+import ManagedView from "./ManagedView.vue";
+import ManualView from "./ManualView.vue";
 
-import { ref, onMounted } from "vue";
-
-// Retrieve the SDK instance to interact with the backend
 const sdk = useSDK();
+const settingsState = provideSettings();
+const licenseState = provideLicense();
 
-const host = ref("");
-const port = ref("");
-const filterInScope = ref(false);
-const isLoading = ref(false);
+const mode = computed<Mode>(() => settingsState.settings.value.mode);
 
-// Load settings from the backend
-const loadSettings = async () => {
-  isLoading.value = true;
-  try {
-    const response = await sdk.backend.getSettings();
-    if (!response.success) {
-      sdk.window.showToast(`Failed to load settings: ${response.error}`, { variant: "error" });
+// Supervisor gate is narrower than the status gate: only fire when the user
+// is Pro AND in managed mode. The supervisor backend never spawns at init
+// (orphan recovery aside), so this is purely a UI subscription gate -- free /
+// manual users don't even attach the event listener.
+const supervisorEnabled = computed(
+  () =>
+    licenseState.isPro.value &&
+    settingsState.isLoaded.value &&
+    mode.value === "managed"
+);
+const supervisorState = provideSupervisor(supervisorEnabled);
+
+// Gate the /health poll: only run when settings are loaded (so we never poll
+// the default 3333 before the user's saved port is read) and the user is Pro
+// (free users have no status card to render).
+const statusEnabled = computed(
+  () => licenseState.isPro.value && settingsState.isLoaded.value
+);
+
+// In managed mode the supervisor auto-allocates its own port at start --
+// the live value lives in snapshot.port, NOT in settings.json (which is
+// shared across parallel Caido instances and intentionally has no managed
+// port preference). Manual mode keeps using settings.port as the
+// user-configured connection target.
+const statusPortOverride = computed<number | null>(() => {
+  if (mode.value !== "managed") return null;
+  return supervisorState.snapshot.value?.port ?? null;
+});
+provideJxscoutStatus(settingsState.settings, statusEnabled, statusPortOverride);
+
+// Binary detection has the same gate as supervisor: Pro + managed mode.
+// Free + Manual users never need it. Phase 5 RPCs collapse failures into a
+// typed result so detection itself is safe to call from this layer.
+provideBinary(supervisorEnabled);
+
+// Scope state: fetches the current jxscout project's scope on every
+// supervisor->running transition so ScopeSettings can populate its textareas
+// from the new project rather than carrying patterns over from the previous
+// one. Save still pushes via POST /scope. Pass the resolved state in (rather
+// than re-injecting) because Vue's inject() during App.vue's setup can't see
+// provides registered on the same instance.
+provideScope(supervisorState);
+
+// Phase 8: auto-sync events (project switch / project closed). Same gate as
+// supervisor -- only subscribe when Pro + managed.
+provideAutoSync(supervisorEnabled);
+
+// Phase 10: lazy project-list cache for the manual project picker. No gate
+// here -- the composable is dormant until a consumer calls refresh() or
+// fetchIfStale(). ProjectPicker is only mounted on ManagedRunning when
+// !autoSync, so in practice only Pro + managed + running users ever hit it.
+provideJxscoutProjects();
+
+// Phase 10: manual project name. Per-Caido-process state (the backend keeps
+// it in module-scope memory only, never in settings.json) so two Caido
+// instances sharing the same Data dir can each pick their own project.
+provideManualProject();
+
+// Phase 9: Managed -> Manual while the supervisor is mid-spawn or running
+// requires user confirmation. Without it, flipping mode leaves the child
+// alive as an orphan -- it survives the mode flip and gets cleaned up only
+// at the next plugin init (recoverOrphan). The dialog gives three explicit
+// outcomes: stop the child, keep it running (treat as Manual external jxscout),
+// or cancel and stay in Managed mode.
+//
+// 'failed' is intentionally NOT included: the child is already gone, so the
+// switch is non-destructive. 'stopped' is excluded for the same reason.
+const isSupervisorActive = computed(() => {
+  const s = supervisorState.snapshot.value?.state;
+  return s === "starting" || s === "running";
+});
+
+const pendingSwitch = ref<Mode | null>(null);
+const confirmDialogOpen = computed(() => pendingSwitch.value !== null);
+
+const onSelectMode = async (next: Mode) => {
+  if (next === mode.value) return;
+  if (next === "manual" && isSupervisorActive.value) {
+    pendingSwitch.value = next;
+    return;
+  }
+  await settingsState.save({ mode: next });
+};
+
+const onConfirmChoice = async (choice: "stop" | "keep" | "cancel") => {
+  const next = pendingSwitch.value;
+  pendingSwitch.value = null;
+  if (next === null || choice === "cancel") return;
+  if (choice === "stop") {
+    // Intent ("did the user want jxscout running?") lives in module-scope
+    // memory on the backend now, not in settings.json -- the supervisor
+    // stop() call updates it, so we only need to flip the mode here.
+    await supervisorState.stop();
+    await settingsState.save({ mode: next });
+    return;
+  }
+  // 'keep': leave intent alone (the supervisor is still running). The user
+  // gets jxscout staying up under Manual mode as an externally-managed
+  // process.
+  await settingsState.save({ mode: next });
+};
+
+// Phase 9: license-removed external detection. useLicense.refresh() runs on
+// every window-focus event; when the user removes ~/.jxscout-pro/.license
+// (or jxscout-pro-v2 clears it on a Keygen heartbeat failure) and refocuses
+// Caido, isPro flips true -> false. We respond with a one-shot toast plus a
+// supervisor stop if it was running.
+//
+// Skipping the initial false -> true transition: licenseState starts at
+// isPro=false, isLoaded=false. The first refresh() in onMounted lands it at
+// isPro=<truth>, isLoaded=true. We only care about transitions AFTER the
+// first authoritative read, so we gate on a sticky `licenseEverLoaded` flag.
+const licenseEverLoaded = ref(false);
+watch(
+  [licenseState.isPro, licenseState.isLoaded],
+  ([isPro, isLoaded], previous) => {
+    if (!isLoaded) return;
+    if (!licenseEverLoaded.value) {
+      licenseEverLoaded.value = true;
       return;
     }
-
-    const settings = response.data;
-
-    host.value = settings.host;
-    port.value = settings.port;
-    filterInScope.value = settings.filterInScope;
-  } catch (error) {
-    sdk.window.showToast(`Failed to load settings: ${error}`, { variant: "error" });
-  } finally {
-    isLoading.value = false;
+    const wasPro = previous?.[0] ?? false;
+    if (wasPro && !isPro) {
+      sdk.window.showToast("License removed — back to Manual mode", {
+        variant: "info",
+      });
+      // supervisorState.stop() routes through stopJxscoutHandler, which
+      // flips the module-scope intended state to "stopped" before killing
+      // the child. Across a Caido restart that intent is lost (it lived in
+      // memory), so re-adding the license + restarting Caido will see
+      // auto-launch fire again -- intentional, to avoid stale gates.
+      const s = supervisorState.snapshot.value?.state;
+      if (s === "starting" || s === "running") {
+        void supervisorState.stop();
+      }
+    }
   }
-};
+);
 
-// Save settings to the backend
-const onSaveClick = async () => {
-  isLoading.value = true;
-  try {
-    await sdk.backend.saveSettings({
-      host: host.value,
-      port: parseInt(port.value),
-      filterInScope: filterInScope.value,
-    });
-    alert("Settings saved successfully!");
-  } catch (error) {
-    console.error("Failed to save settings:", error);
-  } finally {
-    isLoading.value = false;
-  }
-};
-
-// Load settings when the component is mounted
-onMounted(() => {
-  loadSettings();
+onMounted(async () => {
+  await Promise.all([settingsState.load(), licenseState.refresh()]);
 });
 </script>
 
 <template>
-  <div class="flex flex-col p-4 gap-4 max-w-sm">
-    <div>
-      <h1 class="text-xl font-bold">JXScout Settings</h1>
-      <p class="text-sm text-gray-600">Configure ingestion from Caido to JXScout.</p>
+  <!-- Caido's host gives the plugin root height:100%; without overflow-y:auto
+       on this scroll container any content that doesn't fit the viewport gets
+       clipped silently (Phase 8 introduced enough Advanced-settings rows that
+       the Managed view now exceeds typical viewport heights). h-full pins the
+       scroll container to the plugin's allocated height; the inner div keeps
+       the existing max-w-md + gap-3 layout intact. -->
+  <div class="h-full overflow-y-auto">
+    <div class="flex min-w-0 flex-col gap-3 p-3 max-w-md">
+      <p class="m-0 text-sm text-surface-500 dark:text-surface-400">
+        Choose how Caido connects to jxscout.
+      </p>
+
+      <ModeCards
+        :mode="mode"
+        :is-pro="licenseState.isPro.value"
+        :disabled="settingsState.isLoading.value"
+        @select="onSelectMode"
+      />
+
+      <ManualView v-if="mode === 'manual'" />
+      <ManagedView v-else />
     </div>
-    <div class="flex flex-col gap-4">
-      <div class="flex justify-between items-center">
-        <label for="host">Host:</label>
-        <InputText id="host" v-model="host" placeholder="Host" :disabled="isLoading" />
-      </div>
-      <div class="flex justify-between items-center">
-        <label for="port">Port:</label>
-        <InputText id="port" v-model="port" placeholder="Port" :disabled="isLoading" />
-      </div>
-      <div class="flex items-center justify-between">
-        <label for="filter">Filter in scope:</label>
-        <input id="filter" type="checkbox" v-model="filterInScope" :disabled="isLoading" />
-      </div>
-      <Button label="Save Settings" @click="onSaveClick" :disabled="isLoading" />
-    </div>
+
+    <ConfirmModeSwitchDialog
+      :open="confirmDialogOpen"
+      @choice="onConfirmChoice"
+    />
   </div>
 </template>

--- a/packages/frontend/src/views/ManagedView.vue
+++ b/packages/frontend/src/views/ManagedView.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import BinarySetup from "@/components/BinarySetup.vue";
+import LicenseEntry from "@/components/LicenseEntry.vue";
+import ManagedIdle from "@/components/ManagedIdle.vue";
+import ManagedRunning from "@/components/ManagedRunning.vue";
+import { useBinary } from "@/composables/useBinary";
+import { useLicense } from "@/composables/useLicense";
+import { useSupervisor } from "@/composables/useSupervisor";
+
+// Phase 7 routing. The four branches stack from outermost gate to most
+// specific running state:
+//
+//   !isPro                                                -> LicenseEntry
+//   isPro && !binary                                      -> BinarySetup
+//   isPro && binary && state === 'running'                -> ManagedRunning
+//   isPro && binary && state ∈ {stopped, starting, failed} -> ManagedIdle
+//
+// Detection / supervisor refs both gate on `isPro && managed` upstream, so
+// the loaded flags are false for free / Manual users. We hold the
+// LicenseEntry view at the top of the chain regardless of the lower-state
+// readiness -- license entry doesn't need detection or supervisor state.
+const { isPro, isLoaded: licenseLoaded } = useLicense();
+const { hasBinary, isLoaded: binaryLoaded } = useBinary();
+const { snapshot, isLoaded: supervisorLoaded } = useSupervisor();
+
+const state = computed(() => snapshot.value?.state ?? "stopped");
+const isRunning = computed(() => state.value === "running");
+
+// Show a thin "loading…" affordance only while the first detection / state
+// reads are in flight. Avoids a flash of LicenseEntry / BinarySetup before
+// the truth lands.
+const initialChecksReady = computed(
+  () =>
+    licenseLoaded.value &&
+    (!isPro.value || (binaryLoaded.value && supervisorLoaded.value))
+);
+</script>
+
+<template>
+  <LicenseEntry v-if="!isPro" />
+
+  <div
+    v-else-if="!initialChecksReady"
+    class="rounded-md border border-surface-600 bg-surface-800 p-3 text-sm text-surface-500 dark:text-surface-400"
+  >
+    Loading managed jxscout…
+  </div>
+
+  <BinarySetup v-else-if="!hasBinary" />
+
+  <ManagedRunning v-else-if="isRunning" />
+
+  <ManagedIdle v-else />
+</template>

--- a/packages/frontend/src/views/ManualView.vue
+++ b/packages/frontend/src/views/ManualView.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import Button from "primevue/button";
+import Checkbox from "primevue/checkbox";
+import InputNumber from "primevue/inputnumber";
+import InputText from "primevue/inputtext";
+import { computed, ref, watch } from "vue";
+
+import StatusCard from "@/components/StatusCard.vue";
+import { useJxscoutStatus } from "@/composables/useJxscoutStatus";
+import { useLicense } from "@/composables/useLicense";
+import { useSettings } from "@/composables/useSettings";
+
+const { settings, isLoading, save } = useSettings();
+const { isPro } = useLicense();
+const { status } = useJxscoutStatus();
+
+const showStatusCard = computed(() => isPro.value && status.value !== null);
+
+const host = ref(settings.value.host);
+const port = ref<number | null>(settings.value.port);
+const filterInScope = ref(settings.value.filterInScope);
+
+watch(
+  settings,
+  (next) => {
+    host.value = next.host;
+    port.value = next.port;
+    filterInScope.value = next.filterInScope;
+  },
+  { deep: true }
+);
+
+const onSave = async () => {
+  if (port.value === null || !Number.isFinite(port.value)) {
+    return;
+  }
+  await save({
+    host: host.value,
+    port: port.value,
+    filterInScope: filterInScope.value,
+  });
+};
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <StatusCard v-if="showStatusCard" />
+    <div class="flex flex-col gap-1">
+      <label
+        for="jxscout-host"
+        class="text-sm font-medium text-surface-700 dark:text-surface-200"
+        >Host</label
+      >
+      <InputText
+        id="jxscout-host"
+        v-model="host"
+        placeholder="localhost"
+        :disabled="isLoading"
+        fluid
+      />
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <label
+        for="jxscout-port"
+        class="text-sm font-medium text-surface-700 dark:text-surface-200"
+        >Port</label
+      >
+      <InputNumber
+        id="jxscout-port"
+        v-model="port"
+        :use-grouping="false"
+        :min="1"
+        :max="65535"
+        placeholder="3333"
+        :disabled="isLoading"
+        fluid
+      />
+    </div>
+
+    <div class="flex items-center gap-2 pt-1">
+      <Checkbox
+        input-id="jxscout-filter"
+        v-model="filterInScope"
+        binary
+        :disabled="isLoading"
+      />
+      <label
+        for="jxscout-filter"
+        class="text-sm text-surface-700 dark:text-surface-200 select-none cursor-pointer"
+        >Filter in scope</label
+      >
+    </div>
+
+    <div class="flex justify-end pt-2">
+      <Button
+        label="Save Settings"
+        :disabled="isLoading"
+        :loading="isLoading"
+        @click="onSave"
+      />
+    </div>
+  </div>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,62 +9,69 @@ importers:
   .:
     devDependencies:
       '@caido-community/dev':
-        specifier: ^0.1.3
-        version: 0.1.5(postcss@8.5.3)(typescript@5.5.4)(yaml@2.7.1)
+        specifier: 0.1.6
+        version: 0.1.6(postcss@8.5.14)(typescript@5.8.3)(yaml@2.7.1)
       '@caido/tailwindcss':
         specifier: 0.0.1
         version: 0.0.1
       '@vitejs/plugin-vue':
-        specifier: 5.2.1
-        version: 5.2.1(vite@6.0.7(jiti@2.4.2)(yaml@2.7.1))(vue@3.4.37(typescript@5.5.4))
+        specifier: 6.0.1
+        version: 6.0.1(vite@6.0.7(jiti@2.4.2)(yaml@2.7.1))(vue@3.5.34(typescript@5.8.3))
       postcss-prefixwrap:
-        specifier: 1.51.0
-        version: 1.51.0(postcss@8.5.3)
+        specifier: 1.57.2
+        version: 1.57.2(postcss@8.5.14)
       tailwindcss:
         specifier: 3.4.13
         version: 3.4.13
       tailwindcss-primeui:
-        specifier: 0.3.4
-        version: 0.3.4(tailwindcss@3.4.13)
+        specifier: 0.6.1
+        version: 0.6.1(tailwindcss@3.4.13)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 5.8.3
+        version: 5.8.3
 
   packages/backend:
     devDependencies:
       '@caido/sdk-backend':
-        specifier: ^0.51.1
-        version: 0.51.1
+        specifier: 0.56.0
+        version: 0.56.0
+      '@caido/sdk-shared':
+        specifier: 0.2.2
+        version: 0.2.2
 
   packages/frontend:
     dependencies:
       '@caido/primevue':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.3.3
+        version: 0.3.3(primevue@4.1.0(vue@3.5.34(typescript@5.8.3)))
       primevue:
         specifier: 4.1.0
-        version: 4.1.0(vue@3.4.37(typescript@5.5.4))
+        version: 4.1.0(vue@3.5.34(typescript@5.8.3))
       vue:
-        specifier: 3.4.37
-        version: 3.4.37(typescript@5.5.4)
+        specifier: 3.5.34
+        version: 3.5.34(typescript@5.8.3)
     devDependencies:
       '@caido/sdk-backend':
-        specifier: ^0.51.1
-        version: 0.51.1
+        specifier: 0.56.0
+        version: 0.56.0
       '@caido/sdk-frontend':
-        specifier: ^0.51.1
-        version: 0.51.1(@codemirror/state@6.5.2)(@codemirror/view@6.28.1)(vue@3.4.37(typescript@5.5.4))
+        specifier: 0.56.0
+        version: 0.56.0(@ai-sdk/provider@3.0.10)(@codemirror/state@6.6.0)(@codemirror/view@6.42.1)(vue@3.5.34(typescript@5.8.3))
       '@codemirror/view':
-        specifier: 6.28.1
-        version: 6.28.1
+        specifier: 6.42.1
+        version: 6.42.1
       backend:
         specifier: workspace:*
         version: link:../backend
       vue-tsc:
-        specifier: 2.0.29
-        version: 2.0.29(typescript@5.5.4)
+        specifier: 3.2.8
+        version: 3.2.8(typescript@5.8.3)
 
 packages:
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -74,8 +81,16 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.27.0':
@@ -83,45 +98,57 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@caido-community/dev@0.1.5':
-    resolution: {integrity: sha512-mM+komusTlKNViTlAR055KS9pQJk+jKzbFlUb+MKaFuopMG6qS93z6PSz/08uc7u7/i+U7YiiQvaa7c1IXvl6Q==}
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@caido-community/dev@0.1.6':
+    resolution: {integrity: sha512-WAWmPdEahh4e24sO4crt+nvqZryhKsy4yP5QYGoyUKqEYVAct5S/lI9fHdoIRQPJDSds3ayB6jgMKAlifd8BAg==}
     engines: {node: '>=20', pnpm: '>=9'}
     hasBin: true
 
   '@caido/plugin-manifest@0.3.0':
     resolution: {integrity: sha512-HRGHf65K2sfSdaEUwkCNDlurJ4zL0bOUg/Db4u6CrwjTTzmg2gOzP6SzLRj+69gWmxOm5LUjhInNHaMIRmQkHw==}
 
-  '@caido/primevue@0.1.2':
-    resolution: {integrity: sha512-PCv6qyvlWEKB97PLRzPHDjs7ZGW5JQrD6jvJiMEiprfu4IR5/dXiqRJ4M5g293qn+RAffBuiXcna0vWSxrg5lQ==}
-
-  '@caido/quickjs-types@0.20.0':
-    resolution: {integrity: sha512-T3OTw3GjGPtMxASFHZro86Jce+9TVNNbUz2fQCaCbP+Yh+olt5mwTMLNz8uLFo4icgc1WPfyimfFSN23za9UXw==}
-
-  '@caido/sdk-backend@0.51.1':
-    resolution: {integrity: sha512-BvDCcbxXCDcsCvqntpeoKJ475DUZ7H7TXZjIPcoa5WU+ynBpvnDpeoxVoy1UBYQKz9L5ld8MQ3S5oY9wEoNHqQ==}
-
-  '@caido/sdk-frontend@0.51.1':
-    resolution: {integrity: sha512-mop5Fk5Gv9cxm/BGaO6T1NxJHXPqDU6adIrWKjnWOhZnuqOfH+DxU8TpI+k+IRgtPJkmOv4NqfGPx7axLHhM5A==}
+  '@caido/primevue@0.3.3':
+    resolution: {integrity: sha512-y4wam8i8aK716HZLtq7jGcT3VeDeUefB+ulgkCCWPkXPQtfBBpOzImHwv3EvfZhw4EaSoKZbOzoqZ/TO8KgXNw==}
     peerDependencies:
+      primevue: 4.1.0
+
+  '@caido/quickjs-types@0.26.0':
+    resolution: {integrity: sha512-Nnpu87fnTvVxEdLUQXAc9d763vj13GPcQEhSWireuLlDPDgxM/7dK8kZdOhGX/BhWRRZ7nUzNc3IdN+OVdsoSA==}
+
+  '@caido/sdk-backend@0.56.0':
+    resolution: {integrity: sha512-OG0bx0fVkByRanUYokVyeMqzjq2zdXyuqsQ6NcnycI7N1wAEHCu4daoeesy4l+chuFNJxHIxJP8JwP68Rh4SbA==}
+
+  '@caido/sdk-frontend@0.56.0':
+    resolution: {integrity: sha512-1g0KD/8qFgNOfyfLaALJBVEvN44fXjXEYpQLOVyqW9uD1NkrUDG1gvkrxvQziRxUSpoEqzTSqWoiDQCtkQSMjA==}
+    peerDependencies:
+      '@ai-sdk/provider': ^3.0.1
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
       vue: ^3.0.0
 
-  '@caido/sdk-shared@0.1.1':
-    resolution: {integrity: sha512-JAV5ajUqxZdXYPTmDEvIKBZon8I5uHq44ATj0Nj3BVpllRDUGY9kcBd+PXMD50+3lv1CvhR3/f6q24T0+4aVJQ==}
+  '@caido/sdk-shared@0.2.2':
+    resolution: {integrity: sha512-qzfwXrjujNAmXxedQW2YI5Ls5h+Y/MvzHZxd10vnL6IJbRJStZGusDTnFYDWUyiQpCrc5kGuY3fLr8dYh3UHnw==}
 
   '@caido/tailwindcss@0.0.1':
     resolution: {integrity: sha512-BGp7s8BiZv6eBV8x/j0t5nPBVKP7Bm+gJVY4APcFgFkNkrRSRDo0VuXN52OhiHc/+vTg85lrmLO8IWMM5bcJrQ==}
 
-  '@codemirror/state@6.5.2':
-    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
 
-  '@codemirror/view@6.28.1':
-    resolution: {integrity: sha512-BUWr+zCJpMkA/u69HlJmR+YkV4yPpM81HeMkOMZuwFa8iM5uJdEPKAs1icIRZKkKmy0Ub1x9/G3PQLTXdpBxrQ==}
+  '@codemirror/view@6.42.1':
+    resolution: {integrity: sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==}
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -292,6 +319,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -332,6 +362,9 @@ packages:
     resolution: {integrity: sha512-npY8Jy3HX1+Qbv1jCRdAevOcOj355b0x1Wmepa7omhgQFIUVs2o18HGohYml4HJpmEAu6aKnUIhhodFMuglMeQ==}
     engines: {node: '>=12.11.0'}
 
+  '@rolldown/pluginutils@1.0.0-beta.29':
+    resolution: {integrity: sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==}
+
   '@rollup/rollup-android-arm-eabi@4.39.0':
     resolution: {integrity: sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==}
     cpu: [arm]
@@ -366,56 +399,67 @@ packages:
     resolution: {integrity: sha512-mz5POx5Zu58f2xAG5RaRRhp3IZDK7zXGk5sdEDj4o96HeaXhlUwmLFzNlc4hCQi5sGdR12VDgEUqVSHer0lI9g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.39.0':
     resolution: {integrity: sha512-+YDwhM6gUAyakl0CD+bMFpdmwIoRDzZYaTWV3SDRBGkMU/VpIBYXXEvkEcTagw/7VVkL2vA29zU4UVy1mP0/Yw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.39.0':
     resolution: {integrity: sha512-EKf7iF7aK36eEChvlgxGnk7pdJfzfQbNvGV/+l98iiMwU23MwvmV0Ty3pJ0p5WQfm3JRHOytSIqD9LB7Bq7xdQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.39.0':
     resolution: {integrity: sha512-vYanR6MtqC7Z2SNr8gzVnzUul09Wi1kZqJaek3KcIlI/wq5Xtq4ZPIZ0Mr/st/sv/NnaPwy/D4yXg5x0B3aUUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.39.0':
     resolution: {integrity: sha512-NMRUT40+h0FBa5fb+cpxtZoGAggRem16ocVKIv5gDB5uLDgBIwrIsXlGqYbLwW8YyO3WVTk1FkFDjMETYlDqiw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.39.0':
     resolution: {integrity: sha512-0pCNnmxgduJ3YRt+D+kJ6Ai/r+TaePu9ZLENl+ZDV/CdVczXl95CbIiwwswu4L+K7uOIGf6tMo2vm8uadRaICQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.39.0':
     resolution: {integrity: sha512-t7j5Zhr7S4bBtksT73bO6c3Qa2AV/HqiGlj9+KB3gNF5upcVkx+HLgxTm8DK4OkzsOYqbdqbLKwvGMhylJCPhQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.39.0':
     resolution: {integrity: sha512-m6cwI86IvQ7M93MQ2RF5SP8tUjD39Y7rjb1qjHgYh28uAPVU8+k/xYWvxRO3/tBN2pZkSMa5RjnPuUIbrwVxeA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.39.0':
     resolution: {integrity: sha512-iRDJd2ebMunnk2rsSBYlsptCyuINvxUfGwOUldjv5M4tpa93K8tFMeYGpNk2+Nxl+OBJnBzy2/JCscGeO507kA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.39.0':
     resolution: {integrity: sha512-t9jqYw27R6Lx0XKfEFe5vUeEJ5pF3SGIM6gTfONSMb7DuG6z6wfj2yjcoZxHg129veTqU7+wOhY6GX8wmf90dA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.39.0':
     resolution: {integrity: sha512-ThFdkrFDP55AIsIZDKSBWEt/JcWlCzydbZHinZ0F/r1h83qbGeenCt/G/wG2O0reuENDD2tawfAj2s8VK7Bugg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.39.0':
     resolution: {integrity: sha512-jDrLm6yUtbOg2TYB3sBF3acUnAwsIksEYjLeHL+TJv9jg+TmTwdyjnDex27jqEMakNKf3RwwPahDIt7QXCSqRQ==}
@@ -435,70 +479,62 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
-  '@vitejs/plugin-vue@5.2.1':
-    resolution: {integrity: sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  '@vitejs/plugin-vue@6.0.1':
+    resolution: {integrity: sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
-  '@volar/language-core@2.4.12':
-    resolution: {integrity: sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==}
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/source-map@2.4.12':
-    resolution: {integrity: sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==}
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
-  '@volar/typescript@2.4.12':
-    resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
-
-  '@vue/compiler-core@3.4.37':
-    resolution: {integrity: sha512-ZDDT/KiLKuCRXyzWecNzC5vTcubGz4LECAtfGPENpo0nrmqJHwuWtRLxk/Sb9RAKtR9iFflFycbkjkY+W/PZUQ==}
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
 
-  '@vue/compiler-dom@3.4.37':
-    resolution: {integrity: sha512-rIiSmL3YrntvgYV84rekAtU/xfogMUJIclUMeIKEtVBFngOL3IeZHhsH3UaFEgB5iFGpj6IW+8YuM/2Up+vVag==}
+  '@vue/compiler-core@3.5.34':
+    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
 
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
 
-  '@vue/compiler-sfc@3.4.37':
-    resolution: {integrity: sha512-vCfetdas40Wk9aK/WWf8XcVESffsbNkBQwS5t13Y/PcfqKfIwJX2gF+82th6dOpnpbptNMlMjAny80li7TaCIg==}
+  '@vue/compiler-dom@3.5.34':
+    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
 
-  '@vue/compiler-ssr@3.4.37':
-    resolution: {integrity: sha512-TyAgYBWrHlFrt4qpdACh8e9Ms6C/AZQ6A6xLJaWrCL8GCX5DxMzxyeFAEMfU/VFr4tylHm+a2NpfJpcd7+20XA==}
+  '@vue/compiler-sfc@3.5.34':
+    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
 
-  '@vue/compiler-vue2@2.7.16':
-    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+  '@vue/compiler-ssr@3.5.34':
+    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
 
-  '@vue/language-core@2.0.29':
-    resolution: {integrity: sha512-o2qz9JPjhdoVj8D2+9bDXbaI4q2uZTHQA/dbyZT4Bj1FR9viZxDJnLcKVHfxdn6wsOzRgpqIzJEEmSSvgMvDTQ==}
+  '@vue/language-core@3.2.8':
+    resolution: {integrity: sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g==}
+
+  '@vue/reactivity@3.5.34':
+    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
+
+  '@vue/runtime-core@3.5.34':
+    resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
+
+  '@vue/runtime-dom@3.5.34':
+    resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
+
+  '@vue/server-renderer@3.5.34':
+    resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@vue/reactivity@3.4.37':
-    resolution: {integrity: sha512-UmdKXGx0BZ5kkxPqQr3PK3tElz6adTey4307NzZ3whZu19i5VavYal7u2FfOmAzlcDVgE8+X0HZ2LxLb/jgbYw==}
-
-  '@vue/runtime-core@3.4.37':
-    resolution: {integrity: sha512-MNjrVoLV/sirHZoD7QAilU1Ifs7m/KJv4/84QVbE6nyAZGQNVOa1HGxaOzp9YqCG+GpLt1hNDC4RbH+KtanV7w==}
-
-  '@vue/runtime-dom@3.4.37':
-    resolution: {integrity: sha512-Mg2EwgGZqtwKrqdL/FKMF2NEaOHuH+Ks9TQn3DHKyX//hQTYOun+7Tqp1eo0P4Ds+SjltZshOSRq6VsU0baaNg==}
-
-  '@vue/server-renderer@3.4.37':
-    resolution: {integrity: sha512-jZ5FAHDR2KBq2FsRUJW6GKDOAG9lUTX8aBEGq4Vf6B/35I9fPce66BornuwmqmKgfiSlecwuOb6oeoamYMohkg==}
-    peerDependencies:
-      vue: 3.4.37
-
-  '@vue/shared@3.4.37':
-    resolution: {integrity: sha512-nIh8P2fc3DflG8+5Uw8PT/1i17ccFn0xxN/5oE9RfV5SVnd7G0XEFRwakrnNFE/jlS95fpGXDVG5zDETS26nmg==}
+      vue: 3.5.34
 
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
+  '@vue/shared@3.5.34':
+    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -506,6 +542,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  alien-signals@3.1.2:
+    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -604,9 +643,6 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
-  computeds@0.0.1:
-    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
-
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -630,6 +666,9 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -639,11 +678,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  de-indent@1.0.2:
-    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
@@ -697,8 +733,8 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
-  entities@5.0.0:
-    resolution: {integrity: sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==}
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
@@ -799,6 +835,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.1:
@@ -817,10 +854,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -895,6 +928,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
@@ -926,8 +962,8 @@ packages:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
     engines: {node: 20 || >=22}
 
-  magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1060,6 +1096,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -1116,8 +1156,8 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
-  postcss-prefixwrap@1.51.0:
-    resolution: {integrity: sha512-PuP4md5zFSY921dUcLShwSLv2YyyDec0dK9/puXl/lu7ZNvJ1U59+ZEFRMS67xwfNg5nIIlPXnAycPJlhA/Isw==}
+  postcss-prefixwrap@1.57.2:
+    resolution: {integrity: sha512-HKfOJJCFUtZiUu6CaWmxb6JxYZetn8McOuFUa0t4CJ0ZtcxCPlD8COSPu6804xNc4WPBu34BI0h96wkONLd9lQ==}
     peerDependencies:
       postcss: '*'
 
@@ -1127,6 +1167,10 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -1218,11 +1262,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
@@ -1272,6 +1311,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -1308,8 +1348,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwindcss-primeui@0.3.4:
-    resolution: {integrity: sha512-5+Qfoe5Kpq2Iwrd6umBUb3rQH6b7+pL4jxJUId0Su5agUM6TwCyH5Pyl9R0y3QQB3IRuTxBNmeS11B41f+30zw==}
+  tailwindcss-primeui@0.6.1:
+    resolution: {integrity: sha512-T69Rylcrmnt8zy9ik+qZvsLuRIrS9/k6rYJSIgZ1trnbEzGDDQSCIdmfyZknevqiHwpSJHSmQ9XT2C+S/hJY4A==}
     peerDependencies:
       tailwindcss: '>=3.1.0'
 
@@ -1373,8 +1413,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1436,14 +1476,14 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-tsc@2.0.29:
-    resolution: {integrity: sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==}
+  vue-tsc@3.2.8:
+    resolution: {integrity: sha512-27vTLJ6Q2370obOd0PFYoYoKnmXJ521uUIedrs3Zhhhg/8YG10VOCMmwt+JQslatpAMTDbnWiitLnoD5VlIvog==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.4.37:
-    resolution: {integrity: sha512-3vXvNfkKTBsSJ7JP+LyR7GBuwQuckbWvuwAid3xbqK9ppsKt/DUvfqgZ48fgOLEfpy1IacL5f8QhUVl77RaI7A==}
+  vue@3.5.34:
+    resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1497,22 +1537,39 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/types@7.27.0':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@caido-community/dev@0.1.5(postcss@8.5.3)(typescript@5.5.4)(yaml@2.7.1)':
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@caido-community/dev@0.1.6(postcss@8.5.14)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
       '@caido/plugin-manifest': 0.3.0
       chalk: 5.4.1
@@ -1522,7 +1579,7 @@ snapshots:
       glob: 11.0.1
       jiti: 2.4.2
       jszip: 3.10.1
-      tsup: 8.3.5(jiti@2.4.2)(postcss@8.5.3)(typescript@5.5.4)(yaml@2.7.1)
+      tsup: 8.3.5(jiti@2.4.2)(postcss@8.5.14)(typescript@5.8.3)(yaml@2.7.1)
       vite: 6.0.7(jiti@2.4.2)(yaml@2.7.1)
       ws: 8.18.0
       zod: 3.24.1
@@ -1549,22 +1606,25 @@ snapshots:
     dependencies:
       ajv: 8.17.1
 
-  '@caido/primevue@0.1.2': {}
-
-  '@caido/quickjs-types@0.20.0': {}
-
-  '@caido/sdk-backend@0.51.1':
+  '@caido/primevue@0.3.3(primevue@4.1.0(vue@3.5.34(typescript@5.8.3)))':
     dependencies:
-      '@caido/quickjs-types': 0.20.0
-      '@caido/sdk-shared': 0.1.1
+      primevue: 4.1.0(vue@3.5.34(typescript@5.8.3))
 
-  '@caido/sdk-frontend@0.51.1(@codemirror/state@6.5.2)(@codemirror/view@6.28.1)(vue@3.4.37(typescript@5.5.4))':
+  '@caido/quickjs-types@0.26.0': {}
+
+  '@caido/sdk-backend@0.56.0':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.28.1
-      vue: 3.4.37(typescript@5.5.4)
+      '@caido/quickjs-types': 0.26.0
+      '@caido/sdk-shared': 0.2.2
 
-  '@caido/sdk-shared@0.1.1': {}
+  '@caido/sdk-frontend@0.56.0(@ai-sdk/provider@3.0.10)(@codemirror/state@6.6.0)(@codemirror/view@6.42.1)(vue@3.5.34(typescript@5.8.3))':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.42.1
+      vue: 3.5.34(typescript@5.8.3)
+
+  '@caido/sdk-shared@0.2.2': {}
 
   '@caido/tailwindcss@0.0.1':
     dependencies:
@@ -1572,13 +1632,14 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  '@codemirror/state@6.5.2':
+  '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.28.1':
+  '@codemirror/view@6.42.1':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
@@ -1678,6 +1739,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -1706,18 +1769,20 @@ snapshots:
 
   '@primeuix/utils@0.2.0': {}
 
-  '@primevue/core@4.1.0(vue@3.4.37(typescript@5.5.4))':
+  '@primevue/core@4.1.0(vue@3.5.34(typescript@5.8.3))':
     dependencies:
       '@primeuix/styled': 0.2.0
       '@primeuix/utils': 0.2.0
-      vue: 3.4.37(typescript@5.5.4)
+      vue: 3.5.34(typescript@5.8.3)
 
-  '@primevue/icons@4.1.0(vue@3.4.37(typescript@5.5.4))':
+  '@primevue/icons@4.1.0(vue@3.5.34(typescript@5.8.3))':
     dependencies:
       '@primeuix/utils': 0.2.0
-      '@primevue/core': 4.1.0(vue@3.4.37(typescript@5.5.4))
+      '@primevue/core': 4.1.0(vue@3.5.34(typescript@5.8.3))
     transitivePeerDependencies:
       - vue
+
+  '@rolldown/pluginutils@1.0.0-beta.29': {}
 
   '@rollup/rollup-android-arm-eabi@4.39.0':
     optional: true
@@ -1781,30 +1846,23 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.0.7(jiti@2.4.2)(yaml@2.7.1))(vue@3.4.37(typescript@5.5.4))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.0.7(jiti@2.4.2)(yaml@2.7.1))(vue@3.5.34(typescript@5.8.3))':
     dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 6.0.7(jiti@2.4.2)(yaml@2.7.1)
-      vue: 3.4.37(typescript@5.5.4)
+      vue: 3.5.34(typescript@5.8.3)
 
-  '@volar/language-core@2.4.12':
+  '@volar/language-core@2.4.28':
     dependencies:
-      '@volar/source-map': 2.4.12
+      '@volar/source-map': 2.4.28
 
-  '@volar/source-map@2.4.12': {}
+  '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.12':
+  '@volar/typescript@2.4.28':
     dependencies:
-      '@volar/language-core': 2.4.12
+      '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-
-  '@vue/compiler-core@3.4.37':
-    dependencies:
-      '@babel/parser': 7.27.0
-      '@vue/shared': 3.4.37
-      entities: 5.0.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.13':
     dependencies:
@@ -1814,76 +1872,76 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.4.37':
+  '@vue/compiler-core@3.5.34':
     dependencies:
-      '@vue/compiler-core': 3.4.37
-      '@vue/shared': 3.4.37
+      '@babel/parser': 7.29.3
+      '@vue/shared': 3.5.34
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.5.13':
     dependencies:
       '@vue/compiler-core': 3.5.13
       '@vue/shared': 3.5.13
 
-  '@vue/compiler-sfc@3.4.37':
+  '@vue/compiler-dom@3.5.34':
     dependencies:
-      '@babel/parser': 7.27.0
-      '@vue/compiler-core': 3.4.37
-      '@vue/compiler-dom': 3.4.37
-      '@vue/compiler-ssr': 3.4.37
-      '@vue/shared': 3.4.37
+      '@vue/compiler-core': 3.5.34
+      '@vue/shared': 3.5.34
+
+  '@vue/compiler-sfc@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/compiler-core': 3.5.34
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
       estree-walker: 2.0.2
-      magic-string: 0.30.17
-      postcss: 8.5.3
+      magic-string: 0.30.21
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.4.37':
+  '@vue/compiler-ssr@3.5.34':
     dependencies:
-      '@vue/compiler-dom': 3.4.37
-      '@vue/shared': 3.4.37
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
 
-  '@vue/compiler-vue2@2.7.16':
+  '@vue/language-core@3.2.8':
     dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-
-  '@vue/language-core@2.0.29(typescript@5.5.4)':
-    dependencies:
-      '@volar/language-core': 2.4.12
+      '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.13
-      '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.13
-      computeds: 0.0.1
-      minimatch: 9.0.5
+      alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.5.4
+      picomatch: 4.0.4
 
-  '@vue/reactivity@3.4.37':
+  '@vue/reactivity@3.5.34':
     dependencies:
-      '@vue/shared': 3.4.37
+      '@vue/shared': 3.5.34
 
-  '@vue/runtime-core@3.4.37':
+  '@vue/runtime-core@3.5.34':
     dependencies:
-      '@vue/reactivity': 3.4.37
-      '@vue/shared': 3.4.37
+      '@vue/reactivity': 3.5.34
+      '@vue/shared': 3.5.34
 
-  '@vue/runtime-dom@3.4.37':
+  '@vue/runtime-dom@3.5.34':
     dependencies:
-      '@vue/reactivity': 3.4.37
-      '@vue/runtime-core': 3.4.37
-      '@vue/shared': 3.4.37
-      csstype: 3.1.3
+      '@vue/reactivity': 3.5.34
+      '@vue/runtime-core': 3.5.34
+      '@vue/shared': 3.5.34
+      csstype: 3.2.3
 
-  '@vue/server-renderer@3.4.37(vue@3.4.37(typescript@5.5.4))':
+  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.8.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.4.37
-      '@vue/shared': 3.4.37
-      vue: 3.4.37(typescript@5.5.4)
-
-  '@vue/shared@3.4.37': {}
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      vue: 3.5.34(typescript@5.8.3)
 
   '@vue/shared@3.5.13': {}
+
+  '@vue/shared@3.5.34': {}
 
   accepts@2.0.0:
     dependencies:
@@ -1896,6 +1954,8 @@ snapshots:
       fast-uri: 3.0.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@3.1.2: {}
 
   ansi-regex@5.0.1: {}
 
@@ -1991,8 +2051,6 @@ snapshots:
 
   commander@4.1.1: {}
 
-  computeds@0.0.1: {}
-
   consola@3.4.2: {}
 
   content-disposition@1.0.0:
@@ -2007,6 +2065,8 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  crelt@1.0.6: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2015,9 +2075,7 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  csstype@3.1.3: {}
-
-  de-indent@1.0.2: {}
+  csstype@3.2.3: {}
 
   debug@4.3.6:
     dependencies:
@@ -2051,7 +2109,7 @@ snapshots:
 
   entities@4.5.0: {}
 
-  entities@5.0.0: {}
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -2233,8 +2291,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  he@1.2.0: {}
-
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -2295,6 +2351,8 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema@0.4.0: {}
+
   jszip@3.10.1:
     dependencies:
       lie: 3.3.0
@@ -2320,9 +2378,9 @@ snapshots:
 
   lru-cache@11.1.0: {}
 
-  magic-string@0.30.17:
+  magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2417,6 +2475,8 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  picomatch@4.0.4: {}
+
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
@@ -2440,12 +2500,12 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.3
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.7.1):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.14)(yaml@2.7.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
-      postcss: 8.5.3
+      postcss: 8.5.14
       yaml: 2.7.1
 
   postcss-nested@6.2.0(postcss@8.5.3):
@@ -2453,9 +2513,9 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-prefixwrap@1.51.0(postcss@8.5.3):
+  postcss-prefixwrap@1.57.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.14
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -2464,18 +2524,24 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  primevue@4.1.0(vue@3.4.37(typescript@5.5.4)):
+  primevue@4.1.0(vue@3.5.34(typescript@5.8.3)):
     dependencies:
       '@primeuix/styled': 0.2.0
       '@primeuix/utils': 0.2.0
-      '@primevue/core': 4.1.0(vue@3.4.37(typescript@5.5.4))
-      '@primevue/icons': 4.1.0(vue@3.4.37(typescript@5.5.4))
+      '@primevue/core': 4.1.0(vue@3.5.34(typescript@5.8.3))
+      '@primevue/icons': 4.1.0(vue@3.5.34(typescript@5.8.3))
     transitivePeerDependencies:
       - vue
 
@@ -2585,11 +2651,9 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  semver@7.7.1: {}
-
   send@1.2.0:
     dependencies:
-      debug: 4.3.6
+      debug: 4.4.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -2698,7 +2762,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss-primeui@0.3.4(tailwindcss@3.4.13):
+  tailwindcss-primeui@0.6.1(tailwindcss@3.4.13):
     dependencies:
       tailwindcss: 3.4.13
 
@@ -2758,7 +2822,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.3.5(jiti@2.4.2)(postcss@8.5.3)(typescript@5.5.4)(yaml@2.7.1):
+  tsup@8.3.5(jiti@2.4.2)(postcss@8.5.14)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.24.2)
       cac: 6.7.14
@@ -2768,7 +2832,7 @@ snapshots:
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.7.1)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.14)(yaml@2.7.1)
       resolve-from: 5.0.0
       rollup: 4.39.0
       source-map: 0.8.0-beta.0
@@ -2777,8 +2841,8 @@ snapshots:
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.3
-      typescript: 5.5.4
+      postcss: 8.5.14
+      typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -2791,7 +2855,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
-  typescript@5.5.4: {}
+  typescript@5.8.3: {}
 
   unpipe@1.0.0: {}
 
@@ -2813,22 +2877,21 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-tsc@2.0.29(typescript@5.5.4):
+  vue-tsc@3.2.8(typescript@5.8.3):
     dependencies:
-      '@volar/typescript': 2.4.12
-      '@vue/language-core': 2.0.29(typescript@5.5.4)
-      semver: 7.7.1
-      typescript: 5.5.4
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.2.8
+      typescript: 5.8.3
 
-  vue@3.4.37(typescript@5.5.4):
+  vue@3.5.34(typescript@5.8.3):
     dependencies:
-      '@vue/compiler-dom': 3.4.37
-      '@vue/compiler-sfc': 3.4.37
-      '@vue/runtime-dom': 3.4.37
-      '@vue/server-renderer': 3.4.37(vue@3.4.37(typescript@5.5.4))
-      '@vue/shared': 3.4.37
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-sfc': 3.5.34
+      '@vue/runtime-dom': 3.5.34
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.8.3))
+      '@vue/shared': 3.5.34
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
## Introducing managed mode for jxscout pro v2

Brings managed mode to the jxscout Caido plugin. The plugin can now download, supervise, and lifecycle-manage a jxscout pro binary directly, alongside the existing manual (bring-your-own-instance) flow.

### Highlights
- **Managed mode** — the plugin downloads the jxscout pro binary, starts/stops/restarts it under a supervisor, and surfaces live status (uptime, version, PID/port).
- **Manual mode** — unchanged BYO-instance flow, now selectable via mode cards.
- **Project & scope flow** — project picker, auto-sync, and scope sync between Caido and jxscout.
- **Licensing** — license entry/validation for jxscout pro.
- **Robust process supervision** — parent-PID watchdog so a managed jxscout self-exits if Caido dies (Caido's runtime runs no plugin teardown), PID-file isolation for parallel Caido instances, and orphan/stale-lock recovery on launch.

### Version
Bumps the plugin version `0.4.1` → `0.5.0`.

### Validation
- `pnpm install` + `pnpm typecheck` pass for both backend and frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)